### PR TITLE
Treat UTF-16 surrogate pairs as single characters for string min/maxLength

### DIFF
--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -81,7 +81,7 @@ struct Compiler {
     pending_definitions: Vec<(String, NodeRef)>,
 
     any_cache: Option<NodeRef>,
-    lexeme_cache: HashMap<String, NodeRef>,
+    lexeme_cache: HashMap<(String, bool), NodeRef>,
 }
 
 macro_rules! cache {
@@ -286,11 +286,13 @@ impl Compiler {
     }
 
     fn lexeme(&mut self, rx: &str, json_quoted: bool) -> NodeRef {
-        if self.lexeme_cache.contains_key(rx) {
-            return self.lexeme_cache[rx];
+        let rx = rx.to_string();
+        let key = (rx, json_quoted);
+        if self.lexeme_cache.contains_key(&key) {
+            return self.lexeme_cache[&key];
         }
-        let r = self.builder.lexeme(mk_regex(rx), json_quoted);
-        self.lexeme_cache.insert(rx.to_string(), r);
+        let r = self.builder.lexeme(mk_regex(&key.0), json_quoted);
+        self.lexeme_cache.insert(key, r);
         r
     }
 

--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -286,14 +286,13 @@ impl Compiler {
     }
 
     fn lexeme(&mut self, rx: &str, json_quoted: bool) -> NodeRef {
-        let rx = rx.to_string();
-        let key = (rx, json_quoted);
-        if self.lexeme_cache.contains_key(&key) {
-            return self.lexeme_cache[&key];
-        }
-        let r = self.builder.lexeme(mk_regex(&key.0), json_quoted);
-        self.lexeme_cache.insert(key, r);
-        r
+        let key = (rx.to_string(), json_quoted);
+        self.lexeme_cache
+            .entry(key)
+            .or_insert_with(||
+                self.builder.lexeme(mk_regex(rx), json_quoted)
+            )
+            .clone()
     }
 
     fn json_int(


### PR DESCRIPTION
Makes the following test pass:
```json
  {
      "description": "minLength validation",
      "schema": {
          "$schema": "https://json-schema.org/draft/2020-12/schema",
          "minLength": 2
      },
      "tests": [
          {
              "description": "one grapheme is not long enough",
              "data": "\uD83D\uDCA9",
              "valid": false
          }
      ]
  }
```