### PR TITLE
Intersect patterns, format, and min/maxLength

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 [[package]]
 name = "derivre"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/derivre?rev=e03c91e5cfca55876eeaaecb845d4556f0222352#e03c91e5cfca55876eeaaecb845d4556f0222352"
+source = "git+https://github.com/microsoft/derivre?rev=8a7e7224869e12b0bf316db29b9c5a3c8fae761c#8a7e7224869e12b0bf316db29b9c5a3c8fae761c"
 dependencies = [
  "ahash",
  "anyhow",

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 toktrie = { workspace = true }
-derivre = { git = "https://github.com/microsoft/derivre", rev = "e03c91e5cfca55876eeaaecb845d4556f0222352" }
+derivre = { git = "https://github.com/microsoft/derivre", rev = "8a7e7224869e12b0bf316db29b9c5a3c8fae761c" }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = { version = "1.0.132", features = ["preserve_order"] }
 anyhow = "1.0.90"

--- a/parser/src/grammar_builder.rs
+++ b/parser/src/grammar_builder.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::atomic::AtomicU32};
 
-use anyhow::{ensure, Result};
+use anyhow::{bail, ensure, Result};
+use derivre::RegexAst;
 
 use crate::api::{
     GenGrammarOptions, GenOptions, GrammarWithLexer, Node, NodeId, NodeProps, RegexId, RegexNode,
@@ -38,6 +39,53 @@ impl RegexBuilder {
             nodes: vec![],
             node_ids: HashMap::new(),
         }
+    }
+
+    pub fn add_ast(&mut self, ast: RegexAst) -> Result<RegexId> {
+        let id = match ast {
+            RegexAst::And(asts) => {
+                let ids = self.add_asts(asts)?;
+                self.and(ids)
+            },
+            RegexAst::Or(asts) => {
+                let ids = self.add_asts(asts)?;
+                self.add_node(RegexNode::Or(ids))
+            },
+            RegexAst::Concat(asts) => {
+                let ids = self.add_asts(asts)?;
+                self.concat(ids)
+            },
+            RegexAst::LookAhead(ast) => {
+                let id = self.add_ast(*ast)?;
+                self.add_node(RegexNode::LookAhead(id))
+            },
+            RegexAst::Not(ast) => {
+                let id = self.add_ast(*ast)?;
+                self.not(id)
+            },
+            RegexAst::Repeat(ast, min, max)  => {
+                let id = self.add_ast(*ast)?;
+                self.repeat(id, min, Some(max))
+            },
+            RegexAst::Prefixes(_) => {
+                bail!("Prefixes not supported")
+            },
+            RegexAst::EmptyString => self.add_node(RegexNode::EmptyString),
+            RegexAst::NoMatch => self.add_node(RegexNode::NoMatch),
+            RegexAst::Regex(rx) => self.regex(rx),
+            RegexAst::Literal(s) => self.literal(s),
+            RegexAst::ByteLiteral(bytes) => self.add_node(RegexNode::ByteLiteral(bytes)),
+            RegexAst::Byte(b) => self.add_node(RegexNode::Byte(b)),
+            RegexAst::ByteSet(bs) => self.add_node(RegexNode::ByteSet(bs)),
+            RegexAst::ExprRef(_) => {
+                bail!("ExprRef not supported")
+            },
+        };
+        Ok(id)
+    }
+
+    fn add_asts(&mut self, asts: Vec<RegexAst>) -> Result<Vec<RegexId>> {
+        asts.into_iter().map(|ast| self.add_ast(ast)).collect()
     }
 
     pub fn add_node(&mut self, node: RegexNode) -> RegexId {

--- a/parser/src/grammar_builder.rs
+++ b/parser/src/grammar_builder.rs
@@ -46,30 +46,30 @@ impl RegexBuilder {
             RegexAst::And(asts) => {
                 let ids = self.add_asts(asts)?;
                 self.and(ids)
-            },
+            }
             RegexAst::Or(asts) => {
                 let ids = self.add_asts(asts)?;
                 self.add_node(RegexNode::Or(ids))
-            },
+            }
             RegexAst::Concat(asts) => {
                 let ids = self.add_asts(asts)?;
                 self.concat(ids)
-            },
+            }
             RegexAst::LookAhead(ast) => {
                 let id = self.add_ast(*ast)?;
                 self.add_node(RegexNode::LookAhead(id))
-            },
+            }
             RegexAst::Not(ast) => {
                 let id = self.add_ast(*ast)?;
                 self.not(id)
-            },
-            RegexAst::Repeat(ast, min, max)  => {
+            }
+            RegexAst::Repeat(ast, min, max) => {
                 let id = self.add_ast(*ast)?;
                 self.repeat(id, min, Some(max))
-            },
+            }
             RegexAst::Prefixes(_) => {
                 bail!("Prefixes not supported")
-            },
+            }
             RegexAst::EmptyString => self.add_node(RegexNode::EmptyString),
             RegexAst::NoMatch => self.add_node(RegexNode::NoMatch),
             RegexAst::Regex(rx) => self.regex(rx),
@@ -79,7 +79,7 @@ impl RegexBuilder {
             RegexAst::ByteSet(bs) => self.add_node(RegexNode::ByteSet(bs)),
             RegexAst::ExprRef(_) => {
                 bail!("ExprRef not supported")
-            },
+            }
         };
         Ok(id)
     }

--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -215,11 +215,7 @@ impl Compiler {
                 min_length,
                 max_length,
                 regex,
-            } => self.gen_json_string(
-                *min_length,
-                *max_length,
-                regex.clone(),
-            ),
+            } => self.gen_json_string(*min_length, *max_length, regex.clone()),
             Schema::Array {
                 min_items,
                 max_items,
@@ -287,9 +283,7 @@ impl Compiler {
         let key = (rx.to_string(), json_quoted);
         self.lexeme_cache
             .entry(key)
-            .or_insert_with(||
-                self.builder.lexeme(mk_regex(rx), json_quoted)
-            )
+            .or_insert_with(|| self.builder.lexeme(mk_regex(rx), json_quoted))
             .clone()
     }
 
@@ -446,10 +440,7 @@ impl Compiler {
                         .collect::<Vec<_>>();
                     let taken = self.builder.regex.select(taken_name_ids);
                     let not_taken = self.builder.regex.not(taken);
-                    let valid = self
-                        .builder
-                        .regex
-                        .regex(format!("\"({})*\"", CHAR_REGEX));
+                    let valid = self.builder.regex.regex(format!("\"({})*\"", CHAR_REGEX));
                     let valid_and_not_taken = self.builder.regex.and(vec![valid, not_taken]);
                     let rx = RegexSpec::RegexId(valid_and_not_taken);
                     self.builder.lexeme(rx, false)
@@ -550,7 +541,7 @@ impl Compiler {
                         "(?s:.{{{},{}}})",
                         min_length,
                         max_length.map_or("".to_string(), |v| v.to_string())
-                    ))
+                    )),
                 ]);
             }
             // Check if the regex is empty

--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -553,7 +553,15 @@ impl Compiler {
                     ))
                 ]);
             }
-            // TODO: check if ast corresponds to NoMatch and if so return UnsatisfiableSchemaError
+            // Check if the regex is empty
+            let mut builder = derivre::RegexBuilder::new();
+            let expr = builder.mk(&ast)?;
+            let mut regex = builder.to_regex_limited(expr, 10_000)?;
+            if regex.always_empty() {
+                return Err(anyhow!(UnsatisfiableSchemaError {
+                    message: "regex is empty set".to_string(),
+                }));
+            }
             let id = self.builder.regex.add_ast(ast)?;
             let node = self.builder.lexeme(RegexSpec::RegexId(id), true);
             Ok(node)

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -426,7 +426,13 @@ fn compile_contents_map(ctx: &Context, mut schemadict: HashMap<&str, &Value>) ->
             .iter()
             .map(|value| compile_resource(&ctx, ctx.as_resource_ref(value)))
             .collect::<Result<Vec<_>>>()?;
-        let merged = intersect(ctx, vec![siblings].into_iter().chain(options.into_iter()).collect())?;
+        let merged = intersect(
+            ctx,
+            vec![siblings]
+                .into_iter()
+                .chain(options.into_iter())
+                .collect(),
+        )?;
         return Ok(merged);
     }
 
@@ -720,7 +726,8 @@ fn compile_string(
     let pattern_rx = match pattern {
         None => None,
         Some(val) => Some({
-            let s = val.as_str()
+            let s = val
+                .as_str()
                 .ok_or_else(|| anyhow!("Expected string for 'pattern', got {}", limited_str(val)))?
                 .to_string();
             pattern_to_regex(&s)
@@ -729,19 +736,19 @@ fn compile_string(
     let format_rx = match format {
         None => None,
         Some(val) => Some({
-            let key = val.as_str()
+            let key = val
+                .as_str()
                 .ok_or_else(|| anyhow!("Expected string for 'format', got {}", limited_str(val)))?
                 .to_string();
-            let fmt = lookup_format(&key)
-                .ok_or_else(|| anyhow!("Unknown format: {}", key))?;
+            let fmt = lookup_format(&key).ok_or_else(|| anyhow!("Unknown format: {}", key))?;
             pattern_to_regex(&fmt)
-        })
+        }),
     };
     let regex = match (pattern_rx, format_rx) {
         (None, None) => None,
         (None, Some(fmt)) => Some(fmt),
         (Some(pat), None) => Some(pat),
-        (Some(pat), Some(fmt)) => Some(RegexAst::And(vec![pat, fmt]))
+        (Some(pat), Some(fmt)) => Some(RegexAst::And(vec![pat, fmt])),
     };
     Ok(Schema::String {
         min_length,
@@ -761,7 +768,10 @@ fn compile_array(
     let (prefix_items, items) = {
         // Note that draft detection falls back to Draft202012 if the draft is unknown, so let's relax the draft constraint a bit
         // and assume we're in an old draft if additionalItems is present or items is an array
-        if ctx.draft <= Draft::Draft201909 || additional_items.is_some() || matches!(items, Some(Value::Array(..))) {
+        if ctx.draft <= Draft::Draft201909
+            || additional_items.is_some()
+            || matches!(items, Some(Value::Array(..)))
+        {
             match (items, additional_items) {
                 // Treat array items as prefixItems and additionalItems as items in draft 2019-09 and earlier
                 (Some(Value::Array(..)), _) => (items, additional_items),
@@ -961,9 +971,7 @@ fn intersect_two(ctx: &Context, schema0: Schema, schema1: Schema) -> Result<Sche
                 (None, None) => None,
                 (None, Some(r)) => Some(r),
                 (Some(r), None) => Some(r),
-                (Some(r1), Some(r2)) => {
-                    Some(RegexAst::And(vec![r1, r2]))
-                }
+                (Some(r1), Some(r2)) => Some(RegexAst::And(vec![r1, r2])),
             },
         },
         (


### PR DESCRIPTION
@mmoskal a few things here
1. I added a `add_ast` method to the `RegexBuilder` that will traverse a whole `derivre::RegexAst` and add it to the builder. This feels a little clunky, so I'd appreciate your thoughts.
2. I parsed the `pattern` and `format` into `RegexAst`s in `schema.rs` and intersected them early. `minLength` and `maxLength` did not get this treatment, as taking maximums/minimums of numbers feels like a cleaner way to intersect these.
3. To intersect `minLength` and `maxLength` with a regex, I had to do something mirroring what I did in my other open PR, namely using `"(?s:.{{{},{}}})"` with json-quoting rather than `"\"{}{{{},{}}}\""` with `CHAR_REGEX`.
4. The current state of this PR preserves all existing behaviors, but it does NOT yet actually allow intersecting different types of string constraints... This is because json-quoting currently doesn't work with `And` (mentioned in a comment in #87)