### PR TITLE
Safe `oneOf`

### DIFF
--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -423,7 +423,7 @@ impl Schema {
                     required: req2,
                     additional_properties: add2,
                 },
-            ) => req1.intersection(req2).any(|key| {
+            ) => req1.union(req2).any(|key| {
                 let prop1 = props1
                     .get(key)
                     .unwrap_or(add1.as_deref().unwrap_or(&Schema::Any));


### PR DESCRIPTION
Adds a method to check for "verifiable" schema disjointness (returns false if we're not really sure) and uses it to coerce oneOf to anyOf whenever it is provably safe to do so. This includes cases where objects have required properties that are themselves provably disjoint, covering discriminated unions.

We could probably take this one step farther and actually compute the difference between some schemas (e.g. `Schema::Boolean.subtract(Schema::LiteralBoolean{ true }) => Schema::LiteralBoolean{ false }`), but simply checking for disjointness covers some important cases.

Closes (or at least contributes significant progress towards) #77