### PR TITLE
[JSON] `multipleOf`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "derivre"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/derivre?rev=68f0e0af794b53a8bd0b15549c016219376a8b6b#68f0e0af794b53a8bd0b15549c016219376a8b6b"
+source = "git+https://github.com/microsoft/derivre?rev=bfb30e2989e55fa44e5ec9fa503491ac860a6d7c#bfb30e2989e55fa44e5ec9fa503491ac860a6d7c"
 dependencies = [
  "ahash",
  "anyhow",

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 toktrie = { workspace = true }
-derivre = { git = "https://github.com/microsoft/derivre", rev = "68f0e0af794b53a8bd0b15549c016219376a8b6b" }
+derivre = { git = "https://github.com/microsoft/derivre", rev = "bfb30e2989e55fa44e5ec9fa503491ac860a6d7c" }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = { version = "1.0.132", features = ["preserve_order"] }
 anyhow = "1.0.90"

--- a/parser/src/api.rs
+++ b/parser/src/api.rs
@@ -257,6 +257,9 @@ pub enum RegexNode {
         #[serde(default)]
         raw_mode: bool,
     },
+    /// MultipleOf(d, s) matches if the input, interpreted as decimal ASCII number, is a multiple of d*10^-s.
+    /// EmptyString is not included.
+    MultipleOf(u32, u32),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/parser/src/earley/from_guidance.rs
+++ b/parser/src/earley/from_guidance.rs
@@ -87,6 +87,7 @@ fn map_rx_nodes(
                     raw_mode,
                 },
             )),
+            RegexNode::MultipleOf(d, s) => Ok(RegexAst::MultipleOf(d, s)),
         }
     }
 }

--- a/parser/src/grammar_builder.rs
+++ b/parser/src/grammar_builder.rs
@@ -82,9 +82,7 @@ impl RegexBuilder {
                     allowed_escapes: Some(opts.allowed_escapes.clone()),
                 })
             }
-            RegexAst::MultipleOf(_) => {
-                bail!("MultipleOf not supported")
-            }
+            RegexAst::MultipleOf(d, s) => self.add_node(RegexNode::MultipleOf(d, s)),
             RegexAst::ExprRef(_) => {
                 bail!("ExprRef not supported")
             }

--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -791,7 +791,7 @@ fn always_non_empty(ast: &RegexAst) -> bool {
         | RegexAst::ByteLiteral(_)
         | RegexAst::Byte(_)
         | RegexAst::ByteSet(_)
-        | RegexAst::MultipleOf(_) => true,
+        | RegexAst::MultipleOf(_, _) => true,
 
         RegexAst::And(_)
         | RegexAst::Not(_)

--- a/parser/src/json/numeric.rs
+++ b/parser/src/json/numeric.rs
@@ -898,6 +898,7 @@ mod test_decimal {
 mod test_number_bounds {
     use super::{check_number_bounds, Decimal};
 
+    #[derive(Debug)]
     struct Case {
         minimum: Option<f64>,
         maximum: Option<f64>,
@@ -983,19 +984,181 @@ mod test_number_bounds {
                 multiple_of: Decimal::try_from(0.5).ok(),
                 ok: false,
             },
+            // Zero bounds
+            Case {
+                minimum: Some(0.0),
+                maximum: Some(10.0),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: true,
+                multiple_of: Decimal::try_from(2.0).ok(),
+                ok: true,
+            },
+            Case {
+                minimum: Some(0.0),
+                maximum: Some(10.0),
+                exclusive_minimum: true,
+                exclusive_maximum: false,
+                integer: true,
+                multiple_of: Decimal::try_from(2.0).ok(),
+                ok: true,
+            },
+            Case {
+                minimum: Some(0.0),
+                maximum: Some(10.0),
+                exclusive_minimum: true,
+                exclusive_maximum: true,
+                integer: true,
+                multiple_of: Decimal::try_from(2.0).ok(),
+                ok: true,
+            },
+            // Negative ranges
+            Case {
+                minimum: Some(-10.0),
+                maximum: Some(-5.0),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: true,
+                multiple_of: Decimal::try_from(1.0).ok(),
+                ok: true,
+            },
+            Case {
+                minimum: Some(-10.0),
+                maximum: Some(-5.0),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: false,
+                multiple_of: Decimal::try_from(0.1).ok(),
+                ok: true,
+            },
+            // Tiny ranges
+            Case {
+                minimum: Some(1.0),
+                maximum: Some(1.01),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: false,
+                multiple_of: Decimal::try_from(0.005).ok(),
+                ok: true,
+            },
+            Case {
+                minimum: Some(1.0),
+                maximum: Some(1.01),
+                exclusive_minimum: true,
+                exclusive_maximum: true,
+                integer: false,
+                multiple_of: Decimal::try_from(0.005).ok(),
+                ok: true,
+            },
+            Case {
+                minimum: Some(1.0),
+                maximum: Some(1.01),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: false,
+                multiple_of: Decimal::try_from(0.01).ok(),
+                ok: true,
+            },
+            Case {
+                minimum: Some(1.0),
+                maximum: Some(1.01),
+                exclusive_minimum: true,
+                exclusive_maximum: true,
+                integer: false,
+                multiple_of: Decimal::try_from(0.01).ok(),
+                ok: false,
+            },
+            // Large ranges
+            Case {
+                minimum: Some(1.0),
+                maximum: Some(1e9),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: true,
+                multiple_of: Decimal::try_from(100000.0).ok(),
+                ok: true,
+            },
+            // Non-finite values
+            Case {
+                minimum: Some(f64::NEG_INFINITY),
+                maximum: Some(10.0),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: true,
+                multiple_of: Decimal::try_from(1.0).ok(),
+                ok: true,
+            },
+            Case {
+                minimum: Some(0.0),
+                maximum: Some(f64::INFINITY),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: true,
+                multiple_of: Decimal::try_from(1.0).ok(),
+                ok: true,
+            },
+            // `multiple_of` edge cases
+            Case {
+                minimum: Some(1.0),
+                maximum: Some(10.0),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: false,
+                multiple_of: Decimal::try_from(1.0).ok(),
+                ok: true,
+            },
+            Case {
+                minimum: Some(1.0),
+                maximum: Some(10.0),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: false,
+                multiple_of: Decimal::try_from(0.3).ok(),
+                ok: true,
+            },
+            Case {
+                minimum: Some(1.0),
+                maximum: Some(10.0),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: false,
+                multiple_of: Decimal::try_from(0.0).ok(),
+                ok: false,
+            },
+            Case {
+                minimum: Some(0.0),
+                maximum: Some(10.0),
+                exclusive_minimum: true,
+                exclusive_maximum: false,
+                integer: false,
+                multiple_of: Decimal::try_from(0.0).ok(),
+                ok: false,
+            },
+            Case {
+                minimum: Some(0.0),
+                maximum: Some(10.0),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: false,
+                multiple_of: Decimal::try_from(0.0).ok(),
+                ok: true,
+            },
         ];
         for case in cases {
+            let result = check_number_bounds(
+                case.minimum,
+                case.maximum,
+                case.exclusive_minimum,
+                case.exclusive_maximum,
+                case.integer,
+                case.multiple_of.clone(),
+            );
             assert_eq!(
-                check_number_bounds(
-                    case.minimum,
-                    case.maximum,
-                    case.exclusive_minimum,
-                    case.exclusive_maximum,
-                    case.integer,
-                    case.multiple_of
-                )
-                .is_ok(),
-                case.ok
+                result.is_ok(),
+                case.ok,
+                "Failed for case {:?} with result {:?}",
+                case,
+                result
             );
         }
     }

--- a/parser/src/json/numeric.rs
+++ b/parser/src/json/numeric.rs
@@ -558,6 +558,7 @@ pub fn check_number_bounds(
                     ));
                 }
             };
+            return Ok(());
         }
         // If interval is not unbounded in at least one direction, check if the range contains a multiple of multipleOf
         if let (Some(min), Some(max)) = (minimum, maximum) {

--- a/parser/src/json/numeric.rs
+++ b/parser/src/json/numeric.rs
@@ -33,6 +33,10 @@ impl Decimal {
         let coef = (a * b) / gcd(a, b);
         Decimal::new(coef, self.exp.max(other.exp))
     }
+
+    pub fn to_f64(&self) -> f64 {
+        self.coef as f64 / 10.0f64.powi(self.exp as i32)
+    }
 }
 
 impl TryFrom<f64> for Decimal {

--- a/parser/src/json/numeric.rs
+++ b/parser/src/json/numeric.rs
@@ -28,10 +28,10 @@ impl Decimal {
         if self.coef == 0 || other.coef == 0 {
             return Decimal::new(0, 0);
         }
-        let a = self.coef * 10u32.pow(other.exp);
-        let b = other.coef * 10u32.pow(self.exp);
+        let a = self.coef * 10u32.pow(other.exp.saturating_sub(self.exp));
+        let b = other.coef * 10u32.pow(self.exp.saturating_sub(other.exp));
         let coef = (a * b) / gcd(a, b);
-        Decimal::new(coef, self.exp + other.exp)
+        Decimal::new(coef, self.exp.max(other.exp))
     }
 }
 

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -14,7 +14,7 @@ const DEFAULT_DRAFT: Draft = Draft::Draft202012;
 const TYPES: [&str; 6] = ["null", "boolean", "number", "string", "array", "object"];
 
 // Keywords that are implemented in this module
-const IMPLEMENTED: [&str; 23] = [
+const IMPLEMENTED: [&str; 24] = [
     // Core
     "anyOf",
     "oneOf",
@@ -43,6 +43,7 @@ const IMPLEMENTED: [&str; 23] = [
     "maximum",
     "exclusiveMinimum",
     "exclusiveMaximum",
+    "multipleOf",
 ];
 
 // Keywords that are used for metadata or annotations, not directly driving validation.

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use std::{cell::RefCell, mem, rc::Rc};
 
 use super::formats::lookup_format;
+use super::numeric::Decimal;
 
 const DEFAULT_ROOT_URI: &str = "json-schema:///";
 const DEFAULT_DRAFT: Draft = Draft::Draft202012;
@@ -87,6 +88,7 @@ pub enum Schema {
         maximum: Option<f64>,
         exclusive_minimum: Option<f64>,
         exclusive_maximum: Option<f64>,
+        multiple_of: Option<Decimal>,
         integer: bool,
     },
     String {
@@ -257,6 +259,7 @@ impl Schema {
                     exclusive_minimum: emin1,
                     exclusive_maximum: emax1,
                     integer: int1,
+                    multiple_of: mult1,
                 },
                 Schema::Number {
                     minimum: min2,
@@ -264,6 +267,7 @@ impl Schema {
                     exclusive_minimum: emin2,
                     exclusive_maximum: emax2,
                     integer: int2,
+                    multiple_of: mult2,
                 },
             ) => Schema::Number {
                 minimum: opt_max(min1, min2),
@@ -271,6 +275,12 @@ impl Schema {
                 exclusive_minimum: opt_max(emin1, emin2),
                 exclusive_maximum: opt_min(emax1, emax2),
                 integer: int1 || int2,
+                multiple_of: match (mult1, mult2) {
+                    (None, None) => None,
+                    (None, Some(mult)) => Some(mult),
+                    (Some(mult), None) => Some(mult),
+                    (Some(mult1), Some(mult2)) => Some(mult1.lcm(&mult2)),
+                },
             },
             (
                 Schema::String {
@@ -796,6 +806,7 @@ fn compile_const(instance: &Value) -> Result<Schema> {
                 exclusive_minimum: None,
                 exclusive_maximum: None,
                 integer: n.is_i64(),
+                multiple_of: None,
             })
         }
         Value::String(s) => Ok(Schema::String {
@@ -844,6 +855,7 @@ fn compile_type(ctx: &Context, tp: &str, schema: &HashMap<&str, &Value>) -> Resu
             get("exclusiveMinimum"),
             get("exclusiveMaximum"),
             tp == "integer",
+            get("multipleOf"),
         ),
         "string" => compile_string(
             get("minLength"),
@@ -875,6 +887,7 @@ fn compile_numeric(
     exclusive_minimum: Option<&Value>,
     exclusive_maximum: Option<&Value>,
     integer: bool,
+    multiple_of: Option<&Value>,
 ) -> Result<Schema> {
     let minimum = match minimum {
         None => None,
@@ -915,12 +928,23 @@ fn compile_numeric(
             )
         })?),
     };
+    let multiple_of = match multiple_of {
+        None => None,
+        Some(val) => {
+            let f = val.as_f64().ok_or_else(|| {
+                anyhow!("Expected f64 for 'multipleOf', got {}", limited_str(val))
+            })?;
+            // Can discard the sign of f
+            Some(Decimal::try_from(f.abs())?)
+        }
+    };
     Ok(Schema::Number {
         minimum,
         maximum,
         exclusive_minimum,
         exclusive_maximum,
-        integer: integer,
+        integer,
+        multiple_of,
     })
 }
 


### PR DESCRIPTION
Uses new derivre `MultipleOf` functionality to support the JSON `multipleOf` assertion

TODOS:
- [x] check emptiness of float/int regexes when using `multipleOf`
- [x] tests (here and/or in guidance)