### PR TITLE
Allow passing string for `capture_name` in lark syntax

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -111,6 +111,11 @@ for example: `mygen[stop="\n", max_tokens=10, temperature=0.7]: /.*/`
 
 If `stop` is specified (possibly as `""`) the rule is treated as `gen()` in Guidance
 (the lexeme is lazy); otherwise it is treated as `lexeme()` (greedy).
+You can also use `lazy` in place of `stop=""`.
+
+Additionally `foo[capture]: ...` will generate a capture group named `foo` in the output,
+while `foo[capture="bar"]: ...` will generate a capture group named `bar`.
+The body of the rule can be any expression, not just a token.
 
 ### Extended %regex
 

--- a/parser/src/lark/parser.rs
+++ b/parser/src/lark/parser.rs
@@ -158,9 +158,9 @@ impl Parser {
                             rule.temperature = Some(value);
                         }
                         "capture_name" => {
-                            let value = self.expect_token(Token::String)?.value;
-                            let inner = serde_json::from_str(&value).map_err(|e| anyhow!("error parsing string: {e}"))?;
-                            rule.capture_name = Some(inner);
+                            let lexeme = self.expect_token(Token::String)?;
+                            let string = self.parse_simple_string(&lexeme)?;
+                            rule.capture_name = Some(string);
                         }
                         _ => bail!("Unknown attribute: {}", key),
                     }

--- a/parser/src/lark/parser.rs
+++ b/parser/src/lark/parser.rs
@@ -138,7 +138,12 @@ impl Parser {
             let key = self.expect_token(Token::Rule)?.value;
             match key.as_str() {
                 "capture" => {
-                    if rule.capture_name.is_none() {
+                    if self.has_token(Token::Equals) {
+                        self.expect_token(Token::Equals)?;
+                        let lexeme = self.expect_token(Token::String)?;
+                        let string = self.parse_simple_string(&lexeme)?;
+                        rule.capture_name = Some(string);
+                    } else if rule.capture_name.is_none() {
                         rule.capture_name = Some(rule.name.clone());
                     }
                 }
@@ -161,11 +166,6 @@ impl Parser {
                         "temperature" => {
                             let value = self.expect_token(Token::Number)?.value.parse::<f32>()?;
                             rule.temperature = Some(value);
-                        }
-                        "capture_name" => {
-                            let lexeme = self.expect_token(Token::String)?;
-                            let string = self.parse_simple_string(&lexeme)?;
-                            rule.capture_name = Some(string);
                         }
                         _ => bail!("Unknown attribute: {}", key),
                     }

--- a/parser/src/lark/parser.rs
+++ b/parser/src/lark/parser.rs
@@ -137,6 +137,11 @@ impl Parser {
         while !self.has_token(Token::RBracket) {
             let key = self.expect_token(Token::Rule)?.value;
             match key.as_str() {
+                "capture" => {
+                    if rule.capture_name.is_none() {
+                        rule.capture_name = Some(rule.name.clone());
+                    }
+                }
                 "lazy" => {
                     if rule.stop.is_none() {
                         rule.stop = Some(Value::LiteralString("".to_string(), "".to_string()));

--- a/parser/src/lark/parser.rs
+++ b/parser/src/lark/parser.rs
@@ -137,9 +137,6 @@ impl Parser {
         while !self.has_token(Token::RBracket) {
             let key = self.expect_token(Token::Rule)?.value;
             match key.as_str() {
-                "capture" => {
-                    rule.capture_name = Some(rule.name.clone());
-                }
                 "lazy" => {
                     if rule.stop.is_none() {
                         rule.stop = Some(Value::LiteralString("".to_string(), "".to_string()));
@@ -159,6 +156,11 @@ impl Parser {
                         "temperature" => {
                             let value = self.expect_token(Token::Number)?.value.parse::<f32>()?;
                             rule.temperature = Some(value);
+                        }
+                        "capture_name" => {
+                            let value = self.expect_token(Token::String)?.value;
+                            let inner = serde_json::from_str(&value).map_err(|e| anyhow!("error parsing string: {e}"))?;
+                            rule.capture_name = Some(inner);
                         }
                         _ => bail!("Unknown attribute: {}", key),
                     }


### PR DESCRIPTION
allow passing string for capture_name to allow keys that may be illegal rule names