### PR TITLE
Identify special tokens via a sequence of special ids

### DIFF
--- a/python/llguidance/_tokenizer.py
+++ b/python/llguidance/_tokenizer.py
@@ -6,12 +6,14 @@ class TokenizerWrapper:
     eos_token_id: TokenId
     bos_token_id: Optional[TokenId]
     tokens: Sequence[bytes]
+    special_token_ids: Sequence[int]
 
     def __init__(self, gtokenizer) -> None:
         # these are required by LLTokenizer:
         self.eos_token_id = gtokenizer.eos_token_id
         self.bos_token_id = gtokenizer.bos_token_id
         self.tokens = gtokenizer.tokens
+        self.special_token_ids = getattr(gtokenizer, "special_token_ids", [])
         self.is_tokenizer_wrapper = True
 
         # more private stuff

--- a/python_ext/src/py.rs
+++ b/python_ext/src/py.rs
@@ -463,6 +463,22 @@ impl PyTokenizer {
             .getattr("bos_token_id")?
             .extract::<Option<u32>>()?;
 
+        let special_token_ids = tokenizer
+            .getattr("special_token_ids")?
+            .extract::<Vec<u32>>()?;
+
+        for tok_id in special_token_ids {
+            let tok_ix = tok_id as usize;
+            if let Some(token) = tokens.get_mut(tok_ix) {
+                if token
+                    .first()
+                    .is_none_or(|&first_byte| first_byte != TokTrie::SPECIAL_TOKEN_MARKER)
+                {
+                    token.insert(0, TokTrie::SPECIAL_TOKEN_MARKER);
+                }
+            }
+        }
+
         // we want decode_bytes([EOS]) etc to be empty
         tokens[tok_eos as usize] = vec![];
         // if let Some(t) = tok_bos {


### PR DESCRIPTION
Guidance can avoid adding special bytes to the beginning of special tokens by providing a sequence of special token ids