### PR TITLE
Stabilize property order

### DIFF
--- a/json_stats/expected_maskbench.json
+++ b/json_stats/expected_maskbench.json
@@ -3941,9 +3941,7 @@
   "Github_hard---o67517.json": {},
   "Github_hard---o6761.json": {},
   "Github_hard---o6762.json": {},
-  "Github_hard---o6771.json": {
-    "validation_error": "test #4: token not accepted at ⟦{\"⟧ * ⟦version⟧ * ⟦\":\"‧1‧.‧0⟧ forced tokens \"⟦channels⟧\" != \"⟦version⟧\""
-  },
+  "Github_hard---o6771.json": {},
   "Github_hard---o68354.json": {},
   "Github_hard---o68391.json": {
     "json_error": "oneOf constraints are not supported. Enable 'coerce_one_of' option to approximate oneOf with anyOf"
@@ -5897,7 +5895,7 @@
     "json_error": "Unknown format: url"
   },
   "Github_medium---o55361.json": {
-    "json_error": "Unknown format: url"
+    "json_error": "Unknown format: ipandport"
   },
   "Github_medium---o55443.json": {},
   "Github_medium---o55444.json": {},
@@ -7308,7 +7306,7 @@
   },
   "Github_medium---o90938.json": {},
   "Github_medium---o90940.json": {
-    "json_error": "Unimplemented keys: [\"dependencies\"]"
+    "json_error": "Unimplemented keys: [\"not\"]"
   },
   "Github_medium---o90951.json": {},
   "Github_medium---o90954.json": {},
@@ -10492,7 +10490,7 @@
     "json_error": "Unimplemented keys: [\"minProperties\"]"
   },
   "Handwritten---mod309.json": {
-    "json_error": "Unimplemented keys: [\"not\"]"
+    "json_error": "Schema intersection stack level exceeded"
   },
   "Handwritten---notnames1.json": {
     "json_error": "Unimplemented keys: [\"not\", \"patternProperties\"]"
@@ -11063,7 +11061,7 @@
     "json_error": "Unimplemented keys: [\"patternProperties\"]"
   },
   "JsonSchemaStore---debugsettings.json": {
-    "json_error": "Unimplemented keys: [\"not\"]"
+    "json_error": "Unknown format: uri"
   },
   "JsonSchemaStore---dein.json": {
     "json_error": "Unimplemented keys: [\"patternProperties\"]"
@@ -13338,12 +13336,8 @@
   "Snowplow---sp_341_Normalized.json": {
     "json_error": "oneOf constraints are not supported. Enable 'coerce_one_of' option to approximate oneOf with anyOf"
   },
-  "Snowplow---sp_342_Normalized.json": {
-    "validation_error": "test #0: token not accepted at ⟦{\"‧failure‧\":{\"‧messages‧\":[{\"⟧ * ⟦field⟧ * ⟦\":\"‧event‧\",\"‧error⟧ mask: TokenSet: 9/128256; ⟨e⟩ ⟨s⟩ ⟨er⟩ ⟨err⟩ ⟨error⟩ ⟨sc⟩ ⟨schema⟩ ⟨sch⟩ ⟨erro⟩"
-  },
-  "Snowplow---sp_343_Normalized.json": {
-    "validation_error": "test #0: token not accepted at ⟦0‧\",\"‧data‧\":{\"‧event‧\":\"‧Invalid‧ JSON‧\"}}‧}‧},{\"‧schema‧Criterion‧\":\"‧required‧\",\"‧schema‧Key‧\":\"‧ig‧lu‧:‧com‧.s‧now‧pl‧ow‧analytics‧.s‧now‧pl‧ow‧/un‧struct‧_event‧/json‧schema‧/‧1‧-‧0‧-‧0‧\"},{\"‧error‧\":{\"‧error‧\":\"‧ValidationError‧\",\"⟧ * ⟦data⟧ * ⟦Reports‧\":[{\"‧keyword‧\":\"⟧ forced tokens \"⟦schema‧Issues⟧\" != \"⟦data‧Reports⟧\""
-  },
+  "Snowplow---sp_342_Normalized.json": {},
+  "Snowplow---sp_343_Normalized.json": {},
   "Snowplow---sp_344_Normalized.json": {},
   "Snowplow---sp_345_Normalized.json": {},
   "Snowplow---sp_346_Normalized.json": {},

--- a/json_stats/src/json_stats.rs
+++ b/json_stats/src/json_stats.rs
@@ -48,6 +48,10 @@ pub struct CliOptions {
     #[arg(long)]
     llg_masks: bool,
 
+    /// Don't run any llg tests, just re-write test files
+    #[arg(long)]
+    rewrite_files: bool,
+
     /// Disable the slicer optimization
     #[arg(long)]
     llg_disable_slicer: bool,
@@ -885,7 +889,11 @@ impl TestEnv {
 fn main() {
     let mut options = CliOptions::parse();
 
-    if !options.llg_validate_tokens && !options.llg_masks && !options.llg_compile {
+    if !options.llg_validate_tokens
+        && !options.llg_masks
+        && !options.llg_compile
+        && !options.rewrite_files
+    {
         options.llg_masks = true;
     }
     if options.llg_masks {

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -1177,3 +1177,66 @@ mod test_retriever {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_problem_child() {
+        let schema = json!({
+          "allOf": [
+            {
+              "$ref": "#/definitions/word"
+            },
+            {
+              "$ref": "#/definitions/x0"
+            },
+          ],
+          "definitions": {
+            "word": {
+              "type": "object",
+              "properties": {
+                "a": {
+                  "$ref": "#/definitions/word"
+                },
+                "b": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                }
+              },
+              "required": [
+                "b"
+              ],
+              "additionalProperties": true
+            },
+            "x0": {
+              "additionalProperties": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/x1"
+                  },
+                  {
+                    "multipleOf": 2
+                  }
+                ]
+              },
+              "required": [
+                "x0"
+              ]
+            },
+            "x1": {
+              "additionalProperties": {
+                "$ref": "#/definitions/x0"
+              },
+              "required": [
+                "a",
+                "x1"
+              ]
+            },
+          }
+        });
+        let (schema, _) = build_schema(schema, None).unwrap();
+    }
+}

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -534,7 +534,7 @@ impl Default for SchemaBuilderOptions {
     fn default() -> Self {
         SchemaBuilderOptions {
             max_size: 50_000,
-            max_stack_level: 100,
+            max_stack_level: 128,
         }
     }
 }
@@ -1209,58 +1209,30 @@ mod tests {
     #[test]
     fn test_problem_child() {
         let schema = json!({
-          "allOf": [
-            {
-              "$ref": "#/definitions/word"
-            },
-            {
-              "$ref": "#/definitions/x0"
-            },
-          ],
-          "definitions": {
-            "word": {
-              "type": "object",
-              "properties": {
-                "a": {
-                  "$ref": "#/definitions/word"
+            "allOf" : [
+                {"$ref": "#/$defs/tree1"},
+                {"$ref": "#/$defs/tree2"}
+            ],
+            "$defs" : {
+                "tree1": {
+                    "type": "object",
+                    "properties": {
+                        "child": {
+                            "$ref": "#/$defs/tree1"
+                        }
+                    }
                 },
-                "b": {
-                  "type": "integer",
-                  "exclusiveMinimum": 0
+                "tree2": {
+                    "type": "object",
+                    "properties": {
+                        "child": {
+                            "$ref": "#/$defs/tree2"
+                        }
+                    }
                 }
-              },
-              "required": [
-                "b"
-              ],
-              "additionalProperties": true
-            },
-            "x0": {
-              "additionalProperties": {
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/x1"
-                  },
-                  {
-                    "multipleOf": 2
-                  }
-                ]
-              },
-              "required": [
-                "x0"
-              ]
-            },
-            "x1": {
-              "additionalProperties": {
-                "$ref": "#/definitions/x0"
-              },
-              "required": [
-                "a",
-                "x1"
-              ]
-            },
-          }
+            }
         });
-        let (schema, _) = build_schema(schema, None).unwrap();
-        println!("Schema: {:?}", schema);
+        // Test failure amounts to this resulting in a stack overflow
+        let _ = build_schema(schema, None);
     }
 }

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -636,10 +636,7 @@ fn compile_contents_map(ctx: &Context, schemadict: IndexMap<&str, &Value>) -> Re
                     // Make sure we always give type information to ensure we get the smallest union we can
                     current.insert("type", types);
                 }
-                let current_schema = compile_contents_simple(
-                    ctx,
-                    std::mem::take(&mut current),
-                )?;
+                let current_schema = compile_contents_simple(ctx, std::mem::take(&mut current))?;
                 result = result.intersect(current_schema, ctx)?;
             }
             // Finally apply the applicator
@@ -669,8 +666,7 @@ fn compile_contents_map(ctx: &Context, schemadict: IndexMap<&str, &Value>) -> Re
             // Make sure we always give type information to ensure we get the smallest union we can
             current.insert("type", types);
         }
-        let current_schema =
-            compile_contents_simple(ctx, std::mem::take(&mut current))?;
+        let current_schema = compile_contents_simple(ctx, std::mem::take(&mut current))?;
         result = result.intersect(current_schema, ctx)?;
     }
     Ok(result)

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -534,7 +534,7 @@ impl Default for SchemaBuilderOptions {
     fn default() -> Self {
         SchemaBuilderOptions {
             max_size: 50_000,
-            max_stack_level: 128,
+            max_stack_level: 128, // consumes ~2.5k of stack per level
         }
     }
 }

--- a/parser/src/tokenparser.rs
+++ b/parser/src/tokenparser.rs
@@ -6,7 +6,6 @@ use crate::{
     infoln, panic_utils, warn, Instant, Logger,
 };
 use anyhow::{ensure, Result};
-use serde_json::json;
 use toktrie::{InferenceCapabilities, SimpleVob, TokEnv, TokenId, INVALID_TOKEN};
 
 #[derive(Clone)]


### PR DESCRIPTION
# Part 1

The enforced property order during generation is as follows:
1. Each property in the `"properties"` object, in order of appearance
2. Each property in `"required"`, in order of appearance (if not already in `"properties"`)

When two schemas are joined (more than two is defined inductively), the resulting `"properties"` object will have order given by:
1. Each property in the left schema, in order of appearance
2. Each property in the right schema, in order of appearance (if not already in the left schema)
3. Recursive cases: 
   - If the left schema defines a property that is also found in the right schema, the schema of the resulting merged property will be the result of merging the two properties with the same left,right precedence
   - If the left schema defines a property NOT found in the right schema, it will be merged on the right by the right schema's `additionalProperties`
   - If the right schema defines a property NOT found in the left schema, it will be merged on the left by the left schema's `additionalProperties`

When two schemas are joined, the resulting `"required"` array will have order given by:
1. Each property in the left `"required"`, in order of appearance
2. Each property in the right `"required"`, in order of appearance (if not in the left array)

**Note**: precedence in `"properties"` and `"required"` are tracked *separately* as schemas are merged, with the order imposed by the final schema prioritizing `"properties"` over `"required"`.