### PR TITLE
is_none_or->is_some_and

### DIFF
--- a/parser/src/ffi.rs
+++ b/parser/src/ffi.rs
@@ -554,9 +554,9 @@ pub extern "C" fn llg_get_temperature(cc: &LlgConstraint) -> f32 {
 /// Check if constraint is stopped (cannot be extended further).
 #[no_mangle]
 pub extern "C" fn llg_is_stopped(cc: &LlgConstraint) -> bool {
-    cc.constraint
+    !cc.constraint
         .as_ref()
-        .is_none_or(|c| c.step_result().is_stop())
+        .is_some_and(|c| !c.step_result().is_stop())
 }
 
 /// Compute mask for the next token sampling


### PR DESCRIPTION
The former function is only available for Rust >= 1.82.

The build of Chromium in Ubuntu 24.04 LTS, which only has Rust toolchain up to 1.80, [failed](https://launchpadlibrarian.net/790129648/buildlog_snap_ubuntu_noble_arm64_chromium-snap-from-source-dev_BUILDING.txt.gz) with

```
:: error[E0599]: no method named `is_none_or` found for enum `std::option::Option` in the current scope
::    --> ../../third_party/rust/chromium_crates_io/vendor/llguidance-v0_7/src/ffi.rs:555:10
::     |
:: 553 | /     cc.constraint
:: 554 | |         .as_ref()
:: 555 | |         .is_none_or(|c| c.step_result().is_stop())
::     | |_________-^^^^^^^^^^
::     |
:: help: there is a method `is_none` with a similar name, but with different arguments
::    --> /build/rustc-1.80-HrO9we/rustc-1.80-1.80.1+dfsg0ubuntu1/library/core/src/option.rs:653:5
::
:: error: aborting due to 1 previous error
```

By using `is_some_and` instead, 1.70 is enough (README recommends 1.75).