### PR TITLE
dump grammar in errors in LLInterpreter

### DIFF
--- a/parser/src/tokenparser.rs
+++ b/parser/src/tokenparser.rs
@@ -18,6 +18,7 @@ pub struct TokenParser {
     pub logger: Logger,
     pub limits: ParserLimits,
     pub bias_computer: Arc<dyn BiasComputer>,
+    pub dbg_grammar: String,
     last_step_stats: ParserStats,
     max_step_stats: ParserStats,
     eos_token: TokenId,
@@ -106,6 +107,7 @@ impl TokenParser {
             stop_reason: StopReason::NotStopped,
             error_message: None,
             parser,
+            dbg_grammar: String::new(),
             eos_token,
             llm_tokens: Vec::new(),
             llm_bytes: Vec::new(),
@@ -274,7 +276,11 @@ impl TokenParser {
     }
 
     pub fn augment_err(&self, e: impl Display) -> String {
-        format!("{e}\n<state>\n{}\n</state>", self.dump_state())
+        format!(
+            "{e}\n<state>\n{}\n</state><grammar>\n{}\n</grammar>",
+            self.dump_state(),
+            self.dbg_grammar
+        )
     }
 
     pub fn dump_state(&self) -> String {

--- a/python_ext/src/llinterpreter.rs
+++ b/python_ext/src/llinterpreter.rs
@@ -69,7 +69,7 @@ impl LLInterpreter {
             fork: false,
         };
         let logger = Logger::new(0, std::cmp::max(0, log_level) as u32);
-        let inner = fact
+        let mut inner = fact
             .create_parser_from_init_ext(
                 GrammarInit::Serialized(arg),
                 logger,
@@ -77,6 +77,7 @@ impl LLInterpreter {
                 LLParserLimits::from_option(limits),
             )
             .map_err(val_error)?;
+        inner.dbg_grammar = grammar.to_string();
         let inner = Constraint::new(inner);
         Ok(LLInterpreter { inner, log_level })
     }

--- a/sample_parser/tests/test_ll.rs
+++ b/sample_parser/tests/test_ll.rs
@@ -1311,3 +1311,25 @@ fn test_ll_numeric_bug() {
         ],
     );
 }
+
+#[test]
+fn test_stop_crash() {
+    // this fails, see https://github.com/guidance-ai/llguidance/issues/182
+    // check_lark_grammar(
+    //     r#"
+    //         start: prosandcons "Best=" best
+    //         prosandcons[capture, temperature=0.0, max_tokens=600, stop="Best="]: /(?s:.*)/
+    //         best[capture]: /[0-9]+/
+    //     "#,
+    //     &["", " wait‧ times‧.‧\n‧Best‧=‧3‧≺EOS≻"],
+    // );
+
+    check_lark_grammar(
+        r#"
+            start: prosandcons best
+            prosandcons[capture, temperature=0.0, max_tokens=600, suffix="Best="]: /(?s:.*)/
+            best[capture]: /[0-9]+/
+        "#,
+        &["", " wait‧ times‧.‧\n‧Best‧=‧3‧≺EOS≻"],
+    );
+}


### PR DESCRIPTION
This works for Python bindings only currently - include the offending grammar in error dump