### PR TITLE
remove special handling of stop= syntax; see #182

### DIFF
--- a/sample_parser/tests/test_ll.rs
+++ b/sample_parser/tests/test_ll.rs
@@ -600,9 +600,9 @@ fn test_ll_nice_man() {
 #[test]
 fn test_ll_stop_quote_comma() {
     let grm = r#"
-        start: "{ \"items\": [\"" ap "\",\n   \"" bp "\"] }"
-        ap[stop="\""]: /a+/
-        bp[stop="\""]: /b+/
+        start: "{ \"items\": [\"" ap ",\n   \"" bp "] }"
+        ap[suffix="\""]: /a+/
+        bp[suffix="\""]: /b+/
     "#;
 
     // make sure we allow ", as a single token; also "]


### PR DESCRIPTION
This to be merged when Guidance serializes `gen(stop="foo") + "foo"` as `gen(suffix="foo")`

cc @hudson-ai 
