### PR TITLE
Strip debug info from the wheels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ resolver = "2"
 
 [profile.release]
 debug = 1
+strip = "debuginfo"
 # lto = "thin"
 # codegen-units = 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,4 @@ python-source = "python"
 module-name = "llguidance._lib"
 manifest-path = "python_ext/Cargo.toml"
 sdist-generator = "git"
-strip = true
 # features = ["llguidance/logging"]


### PR DESCRIPTION
This greatly shrinks the final wheels, from ~56 MB to ~9.5 MB.

Originally we tried full stripping, that would bring the wheels down to ~7.5 MB. Just symbols seems like a reasonable middle ground.