### PR TITLE
Add lark syntax for "any token" and negation of token ranges

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -70,8 +70,8 @@ You can also use numeric token ids, as in `<[128010]>` (this is `<|python_tag|>`
 Tou can also use ranges like `<[128000-128255]>` for all Llama special tokens, or
 even lists of ranges like `<[128000-128100,128130-128170]>`; ranges are inclusive.
 
-Individual numeric token ids and ranges can be negated with the carat operator, like `<^128000,128130-128170>`.
-This is equivalent to `<0-12799,128001-128129,128171-MAX>`.
+Individual numeric token ids and ranges can be negated with the carat operator, like `<[^128000,128130-128170]>`.
+This is equivalent to `<[0-12799,128001-128129,128171-MAX]>`.
 
 You can also use a *wildcard* token range, `<[*]>`, denoting `<[0-MAX]>`.
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -70,7 +70,7 @@ You can also use numeric token ids, as in `<[128010]>` (this is `<|python_tag|>`
 Tou can also use ranges like `<[128000-128255]>` for all Llama special tokens, or
 even lists of ranges like `<[128000-128100,128130-128170]>`; ranges are inclusive.
 
-Individual numeric token ids and ranges can be negated with the carat operator, like `<[^128000,128130-128170]>`.
+Individual numeric token ids and ranges can be negated with the caret operator, like `<[^128000,128130-128170]>`.
 This is equivalent to `<[0-12799,128001-128129,128171-MAX]>`.
 
 You can also use a *wildcard* token range, `<[*]>`, denoting `<[0-MAX]>`.

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -70,6 +70,11 @@ You can also use numeric token ids, as in `<[128010]>` (this is `<|python_tag|>`
 Tou can also use ranges like `<[128000-128255]>` for all Llama special tokens, or
 even lists of ranges like `<[128000-128100,128130-128170]>`; ranges are inclusive.
 
+Individual numeric token ids and ranges can be negated with the carat operator, like `<^128000,128130-128170>`.
+This is equivalent to `<0-12799,128001-128129,128171-MAX>`.
+
+You can also use a *wildcard* token range, `<[*]>`, denoting `<[0-MAX]>`.
+
 For example, this is how to constrain JSON function calling for Meta Llama 3.1,
 according to their [source repo](https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/prompt_format.md#model-response-format-5) (and yes, it's [different](https://github.com/meta-llama/llama-models/issues/266) than the website).
 

--- a/parser/src/lark/compiler.rs
+++ b/parser/src/lark/compiler.rs
@@ -313,6 +313,8 @@ impl Compiler {
                     Value::SpecialToken(s) => {
                         if s.starts_with("<[") && s.ends_with("]>") {
                             let s = &s[2..s.len() - 2];
+                            let negate = s.starts_with("^");
+                            let s = if negate { &s[1..] } else { s };
                             let mut ranges = vec![];
                             for range in s.split(",") {
                                 let ends: Vec<&str> = range.split('-').map(|s| s.trim()).collect();
@@ -334,7 +336,7 @@ impl Compiler {
                                 ranges.push(start..=end);
                             }
                             ensure!(!ranges.is_empty(), "empty token range");
-                            return self.builder.token_ranges(ranges);
+                            return self.builder.token_ranges(ranges, negate);
                         }
                         return self.builder.special_token(s);
                     }

--- a/parser/src/lark/compiler.rs
+++ b/parser/src/lark/compiler.rs
@@ -339,7 +339,11 @@ impl Compiler {
                                 ranges.push(start..=end);
                             }
                             ensure!(!ranges.is_empty(), "empty token range");
-                            return self.builder.token_ranges(ranges, negate);
+                            return if negate {
+                                self.builder.negated_token_ranges(ranges)
+                            } else {
+                                self.builder.token_ranges(ranges)
+                            };
                         }
                         return self.builder.special_token(s);
                     }

--- a/parser/src/lark/compiler.rs
+++ b/parser/src/lark/compiler.rs
@@ -311,6 +311,9 @@ impl Compiler {
                         return self.do_rule(name, Some(param.clone()));
                     }
                     Value::SpecialToken(s) => {
+                        if s == "<[*]>" {
+                            return self.builder.any_token();
+                        }
                         if s.starts_with("<[") && s.ends_with("]>") {
                             let s = &s[2..s.len() - 2];
                             let negate = s.starts_with("^");

--- a/sample_parser/tests/test_lark.rs
+++ b/sample_parser/tests/test_lark.rs
@@ -318,6 +318,17 @@ fn test_lark_syntax_general() {
     lark_err_test(r#"start: <[,]>"#, "empty token range");
     lark_err_test(r#"start: <[200-100]>"#, "invalid token range");
     lark_err_test(r#"start: <[200 - 100]>"#, "lexer error");
+    lark_ok(r#"start: <[*]>"#);
+    lark_err_test(
+        r#"start: <[^*]>"#,
+        "negated wildcard token <[^*]> is not supported",
+    );
+    lark_err_test(
+        r#"start: <[*,100]>"#,
+        "wildcard token range '*' must not contain additional tokens",
+    );
+    lark_ok(r#"start: <[^100,200-300]>"#);
+    lark_ok(r#"start: <[^100-200,100-300]>"#);
 
     lark_err_test(
         r#"

--- a/sample_parser/tests/test_ll.rs
+++ b/sample_parser/tests/test_ll.rs
@@ -760,6 +760,30 @@ fn test_ll_token_ranges() {
         "#,
         &["<|system|>", "✖<|system|>‧foo‧≺EOS≻"],
     );
+
+    check_lark_grammar(
+        r#"start: <[*]> /.*/
+        "#,
+        &["", "<|system|>‧foo‧≺EOS≻"],
+    );
+
+    check_lark_grammar(
+        r#"start: <[*]> /.*/
+        "#,
+        &["", "foo‧≺EOS≻"],
+    );
+
+    check_lark_grammar(
+        r#"start: <[^32001-32005,32007-32010]> /.*/
+        "#,
+        &["", "foo‧≺EOS≻"],
+    );
+
+    check_lark_grammar(
+        r#"start: <[^32001-32005,32007-32010]> /.*/
+        "#,
+        &["", "<|system|>‧foo‧≺EOS≻"],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Proposes a syntax (`<[*]>`) to address #200, furthermore introduces token-class complements following semantics of regex character classes.
