### PR TITLE
Disable hf tokenizer truncation and padding

### DIFF
--- a/python/llguidance/hf.py
+++ b/python/llguidance/hf.py
@@ -1,7 +1,9 @@
+from copy import copy
 from typing import List, Optional
-from ._lib import LLTokenizer
 
 import transformers
+
+from ._lib import LLTokenizer
 
 
 def from_tokenizer(
@@ -28,15 +30,16 @@ def from_tokenizer(
         # this will JSON-serialize the Rust impl of the tokenizer,
         # including added tokens from tokenizer_config.json
         # (which may be missing from tokenizer.json)
-        s = hf_tokenizer.backend_tokenizer.to_str() # type: ignore
+        backend_tokenizer = copy(hf_tokenizer.backend_tokenizer)
+        # disable padding and truncation on copy before converting to string
+        backend_tokenizer.no_padding()
+        backend_tokenizer.no_truncation()
+        s = backend_tokenizer.to_str()  # type: ignore
         # This is probably not needed - it should figure it out by itself
         # if n_vocab is None:
         #     n_vocab = hf_tokenizer.backend_tokenizer.get_vocab_size(with_added_tokens=True)
         if eos_token is None:
-            eos_token = hf_tokenizer.eos_token_id # type: ignore
-        return LLTokenizer(s,
-                           n_vocab=n_vocab,
-                           eos_token=eos_token,
-                           slices=slices)
+            eos_token = hf_tokenizer.eos_token_id  # type: ignore
+        return LLTokenizer(s, n_vocab=n_vocab, eos_token=eos_token, slices=slices)
     else:
         raise ValueError("Only fast tokenizers are supported")


### PR DESCRIPTION
Should fix https://github.com/guidance-ai/guidance/issues/1322:

Calling a transformers Tokenizer has the side-effect of mutating the "padding" and "truncation" attributes of its backend tokenizer. In particular, these attributes are set to null if no padding/truncation strategy is explicitly passed.

We *also* need to set these attributes to null in order to correctly tokenize.