### PR TITLE
[Bug] `matcher.try_consume_tokens` not checking stop if some tokens are left unconsumed

### DIFF
--- a/parser/src/matcher.rs
+++ b/parser/src/matcher.rs
@@ -166,6 +166,7 @@ impl Matcher {
         self.with_inner(|inner| {
             for (idx, &t) in tokens.iter().enumerate() {
                 if !inner.parser.validate_token(t)? {
+                    let _ = inner.parser.check_stop()?;
                     return Ok(idx);
                 }
                 let bt = inner.parser.consume_token(t)?;

--- a/sample_parser/tests/test_raw_parser.rs
+++ b/sample_parser/tests/test_raw_parser.rs
@@ -293,8 +293,6 @@ fn test_stop_when_try_consume_fails() {
 
     let parser = make_parser(lark);
     let tokens = get_tok_env().tokenize("blahblahblahblahstopblah");
-    println!("tokens: {:?}", tokens);
-
     let mut matcher = Matcher::new(Ok(parser));
 
     // When try_consume_tokens only consumes part of the tokens before hitting the end of the grammar,

--- a/sample_parser/tests/test_raw_parser.rs
+++ b/sample_parser/tests/test_raw_parser.rs
@@ -284,3 +284,29 @@ fn test_lexer_inv_crash() {
         matcher.consume_token(t).unwrap();
     }
 }
+
+#[test]
+fn test_stop_when_try_consume_fails() {
+    let lark = r#"
+        start: "blah"* "stop"
+    "#;
+
+    let parser = make_parser(lark);
+    let tokens = get_tok_env().tokenize("blahblahblahblahstopblah");
+    println!("tokens: {:?}", tokens);
+
+    let mut matcher = Matcher::new(Ok(parser));
+
+    // When try_consume_tokens only consumes part of the tokens before hitting the end of the grammar,
+    // the parser should end up in a stopped state.
+    let consumed = matcher.try_consume_tokens(&tokens).unwrap();
+    assert!(consumed < tokens.len());
+    assert!(matcher.is_stopped());
+
+    // Likewise, if we consume exactly the right number of tokens,
+    // the parser should also end up in a stopped state.
+    matcher.reset().unwrap();
+    assert!(!matcher.is_stopped());
+    matcher.try_consume_tokens(&tokens[..consumed]).unwrap();
+    assert!(matcher.is_stopped());
+}


### PR DESCRIPTION
The bug: (found while debugging https://github.com/guidance-ai/llguidance/issues/211)
`try_consume_tokens` short-circuits when it finds an invalid token, missing the `inner.parser.check_stop` check and failing to put the parser into a stopped state. Subsequent calls to `try_consume_tokens` will always fail, and the parser is prevented from ever moving into a stopped state.

The fix:
Call `inner.parser.check_stop` in the short-circuit condition