### PR TITLE
[Bug] calling `try_consume_tokens` after parser is stopped causes error state

### DIFF
--- a/parser/src/tokenparser.rs
+++ b/parser/src/tokenparser.rs
@@ -333,13 +333,6 @@ impl TokenParser {
 
     fn check_initialized(&self, lbl: &str) -> Result<()> {
         ensure!(!self.is_fresh, "process_prompt() not called in {}", lbl);
-        ensure!(
-            self.stop_reason == StopReason::NotStopped,
-            "parser stopped in {}; {}",
-            lbl,
-            self.error_message()
-                .unwrap_or("no error message".to_string())
-        );
         Ok(())
     }
 

--- a/sample_parser/tests/test_raw_parser.rs
+++ b/sample_parser/tests/test_raw_parser.rs
@@ -293,8 +293,6 @@ fn test_try_consume_after_stop() {
 
     let parser = make_parser(lark);
     let tokens = get_tok_env().tokenize("blahblahblahblahstopblah");
-    println!("tokens: {:?}", tokens);
-
     let mut matcher = Matcher::new(Ok(parser));
 
     for tok in tokens.iter() {

--- a/sample_parser/tests/test_raw_parser.rs
+++ b/sample_parser/tests/test_raw_parser.rs
@@ -284,3 +284,26 @@ fn test_lexer_inv_crash() {
         matcher.consume_token(t).unwrap();
     }
 }
+
+#[test]
+fn test_try_consume_after_stop() {
+    let lark = r#"
+        start: "blah"* "stop"
+    "#;
+
+    let parser = make_parser(lark);
+    let tokens = get_tok_env().tokenize("blahblahblahblahstopblah");
+    println!("tokens: {:?}", tokens);
+
+    let mut matcher = Matcher::new(Ok(parser));
+
+    for tok in tokens.iter() {
+        let is_stopped = matcher.is_stopped();
+        matcher.try_consume_tokens(&[*tok]).unwrap();
+        if is_stopped {
+            assert!(!matcher.is_error());
+            return;
+        }
+    }
+    unreachable!();
+}


### PR DESCRIPTION
Avoids `is_initialized` check (which causes an error state if the parser is stopped) in `validate_token` and `validate_tokens_raw` by checking whether the parser is stopped and returning early if so

Fixes #211