### PR TITLE
[Build] Add code coverage build

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -34,3 +34,19 @@ jobs:
     - name: Update toolchain
       run: rustup component add llvm-tools
 
+    - name: Install grcov
+      run: cargo install grcov
+
+    - name: Build everything
+      run: RUSTFLAGS="-Cinstrument-coverage" cargo build
+
+    - name: Run tests
+      run: LLVM_PROFILE_FILE="llg-%p-%m.profraw" cargo test
+
+    - name: Generate coverage report
+      run: |
+        grcov . --binary-path target/debug/ -s . -t html --branch --ignore-not-existing -o target/debug/coverage/
+
+    - name: Check output
+      run: ls target/debug/coverage/
+

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -50,3 +50,7 @@ jobs:
     - name: Check output
       run: ls target/debug/coverage/
 
+    - uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: target/debug/coverage/

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,6 +4,7 @@ permissions:
 
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       commit_id:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,35 @@
+name: Code Coverage
+permissions:
+  contents: read
+
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_id:
+        description: 'Branch or Commit ID (optional)'
+        required: false
+        type: string
+  schedule:
+    # * is a special character in YAML so we quote this string
+    # Run at 09:30 UTC every day
+    - cron:  '30 09 * * *'
+
+
+env:
+  CARGO_TERM_COLOR: always
+
+
+jobs:
+  code-cov:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo at ${{ github.event_name == 'workflow_dispatch' && inputs.commit_id || github.sha }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_id || github.sha }}
+
+    - name: Update toolchain
+      run: rustup component add llvm-tools
+

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,9 +26,9 @@ jobs:
 
     steps:
     - name: Checkout repo at ${{ github.event_name == 'workflow_dispatch' && inputs.commit_id || github.sha }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_id || github.sha }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_id || github.sha }}
 
     - name: Update toolchain
       run: rustup component add llvm-tools

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -5,16 +5,14 @@ permissions:
 
 on:
   pull_request:
+  push:
+    branches: [ "main" ]
   workflow_dispatch:
     inputs:
       commit_id:
         description: 'Branch or Commit ID (optional)'
         required: false
         type: string
-  schedule:
-    # * is a special character in YAML so we quote this string
-    # Run at 09:30 UTC every day
-    - cron:  '30 09 * * *'
 
 
 env:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -19,6 +19,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Cinstrument-coverage"
+  LLVM_PROFILE_FILE: "llg-%p-%m.profraw"
 
 
 jobs:
@@ -38,14 +40,20 @@ jobs:
       run: cargo install grcov
 
     - name: Build everything
-      run: RUSTFLAGS="-Cinstrument-coverage" cargo build
+      run: cargo build
 
     - name: Run tests
-      run: LLVM_PROFILE_FILE="llg-%p-%m.profraw" cargo test
+      run: cargo test
+
+    - name: Check environment
+      run: |
+        echo "CARGO_TERM_COLOR: $CARGO_TERM_COLOR"
+        echo "RUSTFLAGS: $RUSTFLAGS"
+        echo "LLVM_PROFILE_FILE: $LLVM_PROFILE_FILE"
 
     - name: Generate coverage report
       run: |
-        grcov . --binary-path target/debug/ -s . -t html --branch --ignore-not-existing -o target/debug/coverage/
+        grcov . -s . --binary-path target/debug/ -t html --branch --ignore-not-existing -o target/debug/coverage/
 
     - name: Check output
       run: ls target/debug/coverage/


### PR DESCRIPTION
Adding a new GitHub workflow for code coverage, based on:
https://github.com/mozilla/grcov
For now, this creates an artifact containing the HTML coverage. Uploading to CodeCov (or similar) should also be possible.