### PR TITLE
[Test] Extend JSON test coverage

### DIFF
--- a/sample_parser/tests/common_lark_utils/mod.rs
+++ b/sample_parser/tests/common_lark_utils/mod.rs
@@ -36,6 +36,7 @@ pub fn lark_ok(lark: &str) {
     }
 }
 
+#[allow(dead_code)]
 pub fn lark_err_test(lark: &str, err: &str) {
     match make_parser(lark, false) {
         Err(e) => {
@@ -48,6 +49,7 @@ pub fn lark_err_test(lark: &str, err: &str) {
     }
 }
 
+#[allow(dead_code)]
 pub fn json_err_test(schema: &Value, err: &str) {
     lark_err_test(
         &format!(r#"start: %json {}"#, serde_json::to_string(schema).unwrap()),

--- a/sample_parser/tests/test_json_arrays.rs
+++ b/sample_parser/tests/test_json_arrays.rs
@@ -178,3 +178,39 @@ fn array_with_prefix_items_fixed(#[case] sample_array: &Value) {
 fn array_with_prefix_items_fixed_failures(#[case] sample_array: &Value) {
     json_schema_check(&SIMPLE_PREFIXED_ARRAY_FIXED, sample_array, false);
 }
+
+lazy_static! {
+    static ref SIMPLE_PREFIXED_ARRAY_LENGTH_CONSTRAINED: Value = json!({ "type": "array",
+      "prefixItems": [
+        { "type": "string" }, // First item must be a string
+        { "type": "number" }  // Second item must be a number
+      ],
+      "items": { "type": "boolean" }, // Remaining items must be booleans
+      "minItems": 2,
+        "maxItems": 4
+    });
+}
+
+#[rstest]
+#[case(&json!(["Hello", 3.13]))]
+#[case(&json!(["World", 2.718, false]))]
+#[case(&json!(["Test", 1.0, true, false]))]
+fn array_with_prefix_items_length_constrained(#[case] sample_array: &Value) {
+    json_schema_check(
+        &SIMPLE_PREFIXED_ARRAY_LENGTH_CONSTRAINED,
+        sample_array,
+        true,
+    );
+}
+
+#[rstest]
+#[case::too_short(&json!(["Hello"]))]
+#[case::too_long(&json!(["Hello", 3.14, false, true, true]))]
+#[case::prefix_schema_violation(&json!([2.718, false]))]
+fn array_with_prefix_items_length_constrained_failures(#[case] sample_array: &Value) {
+    json_schema_check(
+        &SIMPLE_PREFIXED_ARRAY_LENGTH_CONSTRAINED,
+        sample_array,
+        false,
+    );
+}

--- a/sample_parser/tests/test_json_arrays.rs
+++ b/sample_parser/tests/test_json_arrays.rs
@@ -128,3 +128,53 @@ fn array_of_objects(#[case] sample_array: &Value) {
 fn array_of_objects_failures(#[case] sample_array: &Value) {
     json_schema_check(&ARRAY_OF_OBJECTS, sample_array, false);
 }
+
+lazy_static! {
+    static ref SIMPLE_PREFIXED_ARRAY: Value = json!({ "type": "array",
+      "prefixItems": [
+        { "type": "string" }, // First item must be a string
+        { "type": "number" }  // Second item must be a number
+      ],
+      "items": { "type": "boolean" } // Remaining items must be booleans
+    });
+}
+
+#[rstest]
+#[case::only_prefix(&json!(["Hello", 42]))]
+#[case::prefix_one_item(&json!(["Cruel", 2.718, true]))]
+#[case::prefix_multiple_items(&json!(["World", 3.14, false, true, false]))]
+fn array_with_prefix_items(#[case] sample_array: &Value) {
+    json_schema_check(&SIMPLE_PREFIXED_ARRAY, sample_array, true);
+}
+
+#[rstest]
+#[case(&json!([3.14]))]
+#[case(&json!(["Hello", 42, 3.14]))]
+#[case(&json!(["Hello", 42, true, "Not a boolean"]))]
+fn array_with_prefix_items_failures(#[case] sample_array: &Value) {
+    json_schema_check(&SIMPLE_PREFIXED_ARRAY, sample_array, false);
+}
+
+lazy_static! {
+    static ref SIMPLE_PREFIXED_ARRAY_FIXED: Value = json!({ "type": "array",
+      "prefixItems": [
+        { "type": "string" }, // First item must be a string
+        { "type": "number" }  // Second item must be a number
+      ],
+      "items": false // No additional items allowed
+    });
+}
+
+#[rstest]
+#[case(&json!(["A"]))]
+#[case(&json!(["B", 42]))]
+fn array_with_prefix_items_fixed(#[case] sample_array: &Value) {
+    json_schema_check(&SIMPLE_PREFIXED_ARRAY_FIXED, sample_array, true);
+}
+
+#[rstest]
+#[case(&json!(["Hello", 42, true]))]
+#[case(&json!([3.14]))]
+fn array_with_prefix_items_fixed_failures(#[case] sample_array: &Value) {
+    json_schema_check(&SIMPLE_PREFIXED_ARRAY_FIXED, sample_array, false);
+}

--- a/sample_parser/tests/test_json_arrays.rs
+++ b/sample_parser/tests/test_json_arrays.rs
@@ -141,15 +141,15 @@ lazy_static! {
 
 #[rstest]
 #[case::only_prefix(&json!(["Hello", 42]))]
-#[case::prefix_one_item(&json!(["Cruel", 2.718, true]))]
-#[case::prefix_multiple_items(&json!(["World", 3.14, false, true, false]))]
+#[case::prefix_one_item(&json!(["Cruel", 817.2, true]))]
+#[case::prefix_multiple_items(&json!(["World", 41.3, false, true, false]))]
 fn array_with_prefix_items(#[case] sample_array: &Value) {
     json_schema_check(&SIMPLE_PREFIXED_ARRAY, sample_array, true);
 }
 
 #[rstest]
-#[case(&json!([3.14]))]
-#[case(&json!(["Hello", 42, 3.14]))]
+#[case(&json!([41.3]))]
+#[case(&json!(["Hello", 42, 41.3]))]
 #[case(&json!(["Hello", 42, true, "Not a boolean"]))]
 fn array_with_prefix_items_failures(#[case] sample_array: &Value) {
     json_schema_check(&SIMPLE_PREFIXED_ARRAY, sample_array, false);
@@ -174,7 +174,7 @@ fn array_with_prefix_items_fixed(#[case] sample_array: &Value) {
 
 #[rstest]
 #[case(&json!(["Hello", 42, true]))]
-#[case(&json!([3.14]))]
+#[case(&json!([41.3]))]
 fn array_with_prefix_items_fixed_failures(#[case] sample_array: &Value) {
     json_schema_check(&SIMPLE_PREFIXED_ARRAY_FIXED, sample_array, false);
 }
@@ -193,7 +193,7 @@ lazy_static! {
 
 #[rstest]
 #[case(&json!(["Hello", 3.13]))]
-#[case(&json!(["World", 2.718, false]))]
+#[case(&json!(["World", 817.2, false]))]
 #[case(&json!(["Test", 1.0, true, false]))]
 fn array_with_prefix_items_length_constrained(#[case] sample_array: &Value) {
     json_schema_check(
@@ -205,8 +205,8 @@ fn array_with_prefix_items_length_constrained(#[case] sample_array: &Value) {
 
 #[rstest]
 #[case::too_short(&json!(["Hello"]))]
-#[case::too_long(&json!(["Hello", 3.14, false, true, true]))]
-#[case::prefix_schema_violation(&json!([2.718, false]))]
+#[case::too_long(&json!(["Hello", 41.3, false, true, true]))]
+#[case::prefix_schema_violation(&json!([817.2, false]))]
 fn array_with_prefix_items_length_constrained_failures(#[case] sample_array: &Value) {
     json_schema_check(
         &SIMPLE_PREFIXED_ARRAY_LENGTH_CONSTRAINED,

--- a/sample_parser/tests/test_json_enum_const.rs
+++ b/sample_parser/tests/test_json_enum_const.rs
@@ -5,9 +5,35 @@ mod common_lark_utils;
 use common_lark_utils::json_schema_check;
 
 #[rstest]
+#[case(&json!(true), false)]
+#[case(&json!(false), true)]
+fn const_boolean(#[case] sample: &Value, #[case] expected_pass: bool) {
+    // Some lovely ambiguity here. The point is that this is a boolean
+    // which must always be 'false'.
+    let schema = json!({
+      "type": "boolean",
+      "const": false
+    });
+    json_schema_check(&schema, sample, expected_pass);
+}
+
+#[rstest]
+#[case(&json!({"name" : "John", "age": 42}), true)]
+#[case(&json!({"name" : "Jane", "age": 42}), false)]
+#[case(&json!({"name" : "John", "age": 52}), false)]
+#[case(&json!({"name" : "John", "age": 42, "location" : "USA"}), false)]
+fn const_object(#[case] sample: &Value, #[case] expected_pass: bool) {
+    let schema = json!({
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "const": { "name": "John", "age": 42 }
+    });
+    json_schema_check(&schema, sample, expected_pass);
+}
+
+#[rstest]
 #[case(&json!({"country": "US"}), true)]
 #[case(&json!({"country": "CA"}), false)]
-fn const_check(#[case] sample: &Value, #[case] expected_pass: bool) {
+fn const_property(#[case] sample: &Value, #[case] expected_pass: bool) {
     let schema = json!({
       "properties": {
         "country": {
@@ -16,6 +42,22 @@ fn const_check(#[case] sample: &Value, #[case] expected_pass: bool) {
       }
     });
     json_schema_check(&schema, sample, expected_pass);
+}
+
+#[rstest]
+#[case(&json!([2, 1]), false)]
+#[case(&json!([2, 3]), true)]
+#[case(&json!([2, 3, true, false]), true)]
+#[case(&json!([2, 3, 1]), false)]
+fn array_with_const_prefix(#[case] sample_array: &Value, #[case] expected_pass: bool) {
+    let schema = json!({ "type": "array",
+      "prefixItems": [
+        { "const": 2 },
+        { "const": 3 }
+      ],
+      "items": { "type": "boolean" }, // Remaining items must be booleans
+    });
+    json_schema_check(&schema, sample_array, expected_pass);
 }
 
 #[rstest]

--- a/sample_parser/tests/test_json_enum_const.rs
+++ b/sample_parser/tests/test_json_enum_const.rs
@@ -5,6 +5,13 @@ mod common_lark_utils;
 use common_lark_utils::json_schema_check;
 
 #[rstest]
+fn const_null() {
+    // This may fall into the 'Excessive Pedantry' bin
+    let schema = &json!({"type":"null", "const":null});
+    json_schema_check(schema, &json!(null), true);
+}
+
+#[rstest]
 #[case(&json!(true), false)]
 #[case(&json!(false), true)]
 fn const_boolean(#[case] sample: &Value, #[case] expected_pass: bool) {
@@ -40,6 +47,19 @@ fn const_property(#[case] sample: &Value, #[case] expected_pass: bool) {
           "const": "US"
         }
       }
+    });
+    json_schema_check(&schema, sample, expected_pass);
+}
+
+#[rstest]
+#[case(&json!([10]), false)]
+#[case(&json!([10, 20]), true)]
+#[case(&json!([10, 20, 30]), false)]
+#[case(&json!([10, "a"]), false)]
+fn const_array(#[case] sample: &Value, #[case] expected_pass: bool) {
+    let schema = json!({
+      "type": "array",
+      "const": [10, 20]
     });
     json_schema_check(&schema, sample, expected_pass);
 }

--- a/sample_parser/tests/test_json_enum_const.rs
+++ b/sample_parser/tests/test_json_enum_const.rs
@@ -1,0 +1,30 @@
+use rstest::*;
+use serde_json::{json, Value};
+
+mod common_lark_utils;
+use common_lark_utils::json_schema_check;
+
+#[rstest]
+#[case(&json!({"country": "US"}), true)]
+#[case(&json!({"country": "CA"}), false)]
+fn const_check(#[case] sample: &Value, #[case] expected_pass: bool) {
+    let schema = json!({
+      "properties": {
+        "country": {
+          "const": "US"
+        }
+      }
+    });
+    json_schema_check(&schema, sample, expected_pass);
+}
+
+#[rstest]
+#[case(&json!(6), true)]
+#[case(&json!(9), true)]
+#[case(&json!(13), true)]
+#[case(&json!(42), false)]
+fn enum_check(#[case] sample: &Value, #[case] expected_pass: bool) {
+    let schema = json!({"enum": [6, 9, 13]});
+
+    json_schema_check(&schema, sample, expected_pass);
+}

--- a/sample_parser/tests/test_json_primitives.rs
+++ b/sample_parser/tests/test_json_primitives.rs
@@ -198,6 +198,14 @@ fn integer_limits_empty() {
     );
 }
 
+#[rstest]
+fn integer_multipleof(#[values(0, 3, 12, 1818)] test_value: i64) {
+    // Not sure if this should also work for negative integers too
+    const MULTIPLE_OF: i64 = 3;
+    let schema = &json!({"type":"integer", "multipleOf": MULTIPLE_OF});
+    json_schema_check(schema, &json!(test_value), test_value % MULTIPLE_OF == 0);
+}
+
 // ============================================================================
 
 #[rstest]

--- a/sample_parser/tests/test_json_primitives.rs
+++ b/sample_parser/tests/test_json_primitives.rs
@@ -200,7 +200,7 @@ fn integer_limits_empty() {
 
 #[rstest]
 fn integer_multipleof(#[values(0, 3, 12, 1818)] test_value: i64) {
-    // Not sure if this should also work for negative integers too
+    // See also issue 222
     const MULTIPLE_OF: i64 = 3;
     let schema = &json!({"type":"integer", "multipleOf": MULTIPLE_OF});
     json_schema_check(schema, &json!(test_value), test_value % MULTIPLE_OF == 0);

--- a/sample_parser/tests/test_json_primitives.rs
+++ b/sample_parser/tests/test_json_primitives.rs
@@ -199,12 +199,25 @@ fn integer_limits_empty() {
 }
 
 #[rstest]
-fn integer_multipleof(#[values(0, 3, 12, 1818)] test_value: i64) {
-    // See also issue 222
+fn integer_multipleof(#[values(0, 1, 3, 12, 1818, 1819)] test_value: i64) {
+    // See also issue 222: want to add some negative values
     const MULTIPLE_OF: i64 = 3;
     let schema = &json!({"type":"integer", "multipleOf": MULTIPLE_OF});
     json_schema_check(schema, &json!(test_value), test_value % MULTIPLE_OF == 0);
 }
+
+/*
+Not clear if this should work
+#[rstest]
+fn integer_multipleof_zero(#[values(0, 3, 12, 1818)] test_value: i64) {
+    let schema = &json!({"type":"integer", "multipleOf": 0});
+    json_schema_check(
+        schema,
+        &json!(test_value),
+        if test_value == 0 { true } else { false },
+    );
+}
+*/
 
 // ============================================================================
 
@@ -373,6 +386,52 @@ fn number_limits_incompatible(
         "Unsatisfiable schema: minimum (-0.1) is greater than maximum (-1)",
     );
 }
+
+#[rstest]
+// Issue 222 #[case(-5.0, false)]
+// Issue 222 #[case(-3.0, true)]
+// Issue 222 #[case(0.0, true)]
+// Issue 222 #[case(3.0, true)]
+#[case(3.5, false)]
+// Issue 222 #[case(12.0, true)]
+// Issue 222 #[case(3e22, true)]
+fn number_multipleof(#[case] test_value: f64, #[case] expected_pass: bool) {
+    // See also issue 222
+    const MULTIPLE_OF: f64 = 3.0;
+    let schema = &json!({"type":"number", "multipleOf": MULTIPLE_OF});
+    json_schema_check(schema, &json!(test_value), expected_pass);
+}
+
+#[rstest]
+// Issue 222 #[case(-35.0, true)]
+// Issue 222 #[case(-30.0, false)]
+// Issue 222 #[case(-7.0, true)]
+#[case(0.0, true)]
+#[case(3.5, true)]
+#[case(4.0, false)]
+#[case(325.5, true)]
+#[case(326.5, false)]
+// Issue 222 #[case(3.5e22, true)]
+fn number_multipleof_noninteger(#[case] test_value: f64, #[case] expected_pass: bool) {
+    // See also issue 222
+    const MULTIPLE_OF: f64 = 3.5;
+    let schema = &json!({"type":"number", "multipleOf": MULTIPLE_OF});
+    json_schema_check(schema, &json!(test_value), expected_pass);
+}
+
+/*
+Not clear if this should work
+#[rstest]
+fn number_multipleof_zero(#[values(0.0, 3.0, 12.0, 1818.0)] test_value: f64) {
+    const MULTIPLE_OF: f64 = 0.0;
+    let schema = &json!({"type":"number", "multipleOf": MULTIPLE_OF});
+    json_schema_check(
+        schema,
+        &json!(test_value),
+        if test_value == 0.0 { true } else { false },
+    );
+}
+*/
 
 // ============================================================================
 

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -5,7 +5,7 @@ use rstest::*;
 use serde_json::{json, Value};
 
 mod common_lark_utils;
-use common_lark_utils::{json_err_test, json_schema_check};
+use common_lark_utils::json_schema_check;
 
 lazy_static! {
     static ref SIMPLE_ANYOF: Value = json!({"anyOf": [
@@ -15,12 +15,12 @@ lazy_static! {
 }
 
 #[rstest]
-fn simple_anyof(#[values(&json!(42), &json!(true))] sample: &Value) {
+fn simple_anyof(#[values(json!(42), json!(true))] sample: Value) {
     json_schema_check(&SIMPLE_ANYOF, &sample, true);
 }
 
 #[rstest]
-fn simple_anyof_failures(#[values(&json!("string"), &json!(1.2), &json!([1, 2]))] sample: &Value) {
+fn simple_anyof_failures(#[values(json!("string"), json!(1.2), json!([1, 2]))] sample: Value) {
     json_schema_check(&SIMPLE_ANYOF, &sample, false);
 }
 
@@ -35,14 +35,14 @@ lazy_static! {
 }
 
 #[rstest]
-fn simple_allof(#[values(&json!({"foo": "hello", "bar": 42}))] sample: &Value) {
+fn simple_allof(#[values(json!({"foo": "hello", "bar": 42}))] sample: Value) {
     json_schema_check(&SIMPLE_ALLOF, &sample, true);
 }
 
 #[rstest]
 fn simple_allof_failures(
-    #[values(&json!({"foo": "hello"}), &json!({"bar": 42}), &json!({"foo": "hello", "bar": "not a number"}) )]
-    sample: &Value,
+    #[values(json!({"foo": "hello"}), json!({"bar": 42}), json!({"foo": "hello", "bar": "not a number"}) )]
+    sample: Value,
 ) {
     json_schema_check(&SIMPLE_ALLOF, &sample, false);
 }

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -98,3 +98,19 @@ fn allof_unsatisfiable() {
         "Unsatisfiable schema: minimum (10) is greater than maximum (5)",
     );
 }
+
+#[rstest]
+fn allof_anyof_oneof_combined() {
+    let schema = &json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [{"enum": [2, 6, 10, 30]}],
+            "anyOf": [{"enum": [3, 6, 15, 30]}],
+            "oneOf": [{"enum": [5, 10, 15, 30]}],
+    });
+
+    for i in -35..=35 {
+        let value = json!(i);
+        let expected_pass = i == 30;
+        json_schema_check(schema, &value, expected_pass);
+    }
+}

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -96,6 +96,24 @@ fn allof_simple_minimum(#[case] value: i32, #[case] expected_pass: bool) {
 }
 
 #[rstest]
+#[case("a", true)]
+#[case("b", true)]
+// Issue 224 #[case("bb", false)]
+// Issue 224 #[case("aa", false)]
+#[case("", false)]
+#[case(" ", false)]
+fn allof_string_patterns(#[case] value: &str, #[case] expected_pass: bool) {
+    let schema = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [
+            {"type": "string", "pattern": r"\w+"},
+            {"type": "string", "pattern": r"\w?"}
+        ]
+    });
+    json_schema_check(&schema, &json!(value), expected_pass);
+}
+
+#[rstest]
 fn allof_unsatisfiable_false_schema(#[values(true, false)] other_schema: bool) {
     let schema = &json!({
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -1,0 +1,48 @@
+// This is for testing anyOf and allOf in JSON schema
+
+use lazy_static::lazy_static;
+use rstest::*;
+use serde_json::{json, Value};
+
+mod common_lark_utils;
+use common_lark_utils::{json_err_test, json_schema_check};
+
+lazy_static! {
+    static ref SIMPLE_ANYOF: Value = json!({"anyOf": [
+        {"type": "integer"},
+        {"type": "boolean"}
+    ]});
+}
+
+#[rstest]
+fn simple_anyof(#[values(&json!(42), &json!(true))] sample: &Value) {
+    json_schema_check(&SIMPLE_ANYOF, &sample, true);
+}
+
+#[rstest]
+fn simple_anyof_failures(#[values(&json!("string"), &json!(1.2), &json!([1, 2]))] sample: &Value) {
+    json_schema_check(&SIMPLE_ANYOF, &sample, false);
+}
+
+lazy_static! {
+    static ref SIMPLE_ALLOF: Value = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [
+            {"properties": {"foo": {"type": "string"}}, "required": ["foo"]},
+            {"properties": {"bar": {"type": "integer"}}, "required": ["bar"]},
+        ],
+    });
+}
+
+#[rstest]
+fn simple_allof(#[values(&json!({"foo": "hello", "bar": 42}))] sample: &Value) {
+    json_schema_check(&SIMPLE_ALLOF, &sample, true);
+}
+
+#[rstest]
+fn simple_allof_failures(
+    #[values(&json!({"foo": "hello"}), &json!({"bar": 42}), &json!({"foo": "hello", "bar": "not a number"}) )]
+    sample: &Value,
+) {
+    json_schema_check(&SIMPLE_ALLOF, &sample, false);
+}

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -5,7 +5,7 @@ use rstest::*;
 use serde_json::{json, Value};
 
 mod common_lark_utils;
-use common_lark_utils::json_schema_check;
+use common_lark_utils::{json_err_test, json_schema_check};
 
 lazy_static! {
     static ref SIMPLE_ANYOF: Value = json!({"anyOf": [
@@ -82,4 +82,19 @@ fn allof_simple_minimum(#[case] value: i32, #[case] expected_pass: bool) {
         "allOf": [{"minimum": 30}, {"minimum": 20}],
     });
     json_schema_check(&schema, &json!(value), expected_pass);
+}
+
+#[rstest]
+fn allof_unsatisfiable() {
+    let schema = &json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [
+            {"type": "integer", "minimum": 10},
+            {"type": "integer", "maximum": 5}
+        ]
+    });
+    json_err_test(
+        schema,
+        "Unsatisfiable schema: minimum (10) is greater than maximum (5)",
+    );
 }

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -46,3 +46,40 @@ fn simple_allof_failures(
 ) {
     json_schema_check(&SIMPLE_ALLOF, &sample, false);
 }
+
+lazy_static! {
+    static ref ALLOF_WITH_BASE: Value = json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"bar": {"type": "integer"}},
+            "required": ["bar"],
+            "allOf": [
+                {"properties": {"foo": {"type": "string"}}, "required": ["foo"]},
+                {"properties": {"baz": {"type": "null"}}, "required": ["baz"]},
+            ],
+    });
+}
+
+#[rstest]
+#[case(&json!({"bar": 2, "foo": "quux", "baz": null}), true)]
+#[case(&json!({"foo": "quux", "baz": null}), false)]
+#[case(&json!({"bar": 2, "baz": null}), false)]
+#[case(&json!({"bar": 2, "foo": "quux"}), false)]
+#[case(&json!({"bar": 2}), false)]
+fn allof_with_base(#[case] sample: &Value, #[case] expected_pass: bool) {
+    json_schema_check(&ALLOF_WITH_BASE, sample, expected_pass);
+}
+
+#[rstest]
+#[case(-35, false)]
+#[case(0, false)]
+#[case(29, false)]
+#[case(30, true)]
+#[case(35, true)]
+#[case(381925, true)]
+fn allof_simple_minimum(#[case] value: i32, #[case] expected_pass: bool) {
+    let schema = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [{"minimum": 30}, {"minimum": 20}],
+    });
+    json_schema_check(&schema, &json!(value), expected_pass);
+}

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -24,6 +24,17 @@ fn simple_anyof_failures(#[values(json!("string"), json!(1.2), json!([1, 2]))] s
     json_schema_check(&SIMPLE_ANYOF, &sample, false);
 }
 
+#[rstest]
+#[case(&json!(true), true)]
+#[case(&json!(42), true)]
+#[case(&json!("string"), false)]
+#[case(&json!([1, 2]), false)]
+fn type_as_list(#[case] sample: &Value, #[case] expected_pass: bool) {
+    // Turns out that "type" can be a list, which acts like anyOf
+    let schema = json!({"type": ["boolean", "integer"]});
+    json_schema_check(&schema, sample, expected_pass);
+}
+
 lazy_static! {
     static ref SIMPLE_ALLOF: Value = json!({
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -96,6 +96,15 @@ fn allof_simple_minimum(#[case] value: i32, #[case] expected_pass: bool) {
 }
 
 #[rstest]
+fn allof_unsatisfiable_false_schema(#[values(true, false)] other_schema: bool) {
+    let schema = &json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [other_schema, false],
+    });
+    json_err_test(schema, "Unsatisfiable schema: schema is false");
+}
+
+#[rstest]
 fn allof_unsatisfiable() {
     let schema = &json!({
         "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Having taken a look at code coverage, port some more of the Python-based JSON tests into the Rust layer. This includes tests for:
- prefixItems
- anyOf
- allOf
- multipleOf
- const
- enum

These are not as extensive as the Python tests, but will let some more issues get caught sooner.