### PR TITLE
[JSON] Allow negative test values for `multipleOf`

### DIFF
--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -293,14 +293,10 @@ impl Compiler {
         })?;
         let mut ast = RegexAst::Regex(rx);
         if let Some(d) = num.multiple_of.as_ref() {
-            let multiple_rx = if d.coef == 0 {
-                RegexAst::Literal("0".to_string())
-            } else {
-                RegexAst::Concat(vec![
-                    RegexAst::Regex("-?".to_string()),
-                    RegexAst::MultipleOf(d.coef, d.exp),
-                ])
-            };
+            let multiple_rx = RegexAst::Concat(vec![
+                RegexAst::Regex("-?".to_string()),
+                RegexAst::MultipleOf(d.coef, d.exp),
+            ]);
             ast = RegexAst::And(vec![ast, multiple_rx]);
         }
         Ok(ast)
@@ -322,14 +318,10 @@ impl Compiler {
             })?;
         let mut ast = RegexAst::Regex(rx);
         if let Some(d) = num.multiple_of.as_ref() {
-            let multiple_rx = if d.coef == 0 {
-                RegexAst::Literal("0".to_string())
-            } else {
-                RegexAst::Concat(vec![
-                    RegexAst::Regex("-?".to_string()),
-                    RegexAst::MultipleOf(d.coef, d.exp),
-                ])
-            };
+            let multiple_rx = RegexAst::Concat(vec![
+                RegexAst::Regex("-?".to_string()),
+                RegexAst::MultipleOf(d.coef, d.exp),
+            ]);
             ast = RegexAst::And(vec![ast, multiple_rx]);
         }
         Ok(ast)

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -920,8 +920,10 @@ fn compile_numeric(schema: &HashMap<&str, &Value>, integer: bool) -> Result<Sche
             let f = val.as_f64().ok_or_else(|| {
                 anyhow!("Expected f64 for 'multipleOf', got {}", limited_str(val))
             })?;
-            // Can discard the sign of f
-            Some(Decimal::try_from(f.abs())?)
+            if f <= 0.0 {
+                bail!("'multipleOf' must be a positive number, got {}", f);
+            }
+            Some(Decimal::try_from(f)?)
         }
     };
     Ok(Schema::Number(NumberSchema {

--- a/sample_parser/tests/test_json_primitives.rs
+++ b/sample_parser/tests/test_json_primitives.rs
@@ -472,32 +472,39 @@ fn string_length_unsatisfiable() {
     );
 }
 
-#[test]
-fn test_multiple_of_zero() {
-    let schema = &json!({"type":"integer", "multipleOf": 0});
-    json_schema_check(schema, &json!(0), true);
-    json_schema_check(schema, &json!(1), false);
-    json_schema_check(schema, &json!(-1), false);
-}
-
-#[test]
-fn test_multiple_of_zero_float() {
-    let schema = &json!({"type":"number", "multipleOf": 0});
-    json_schema_check(schema, &json!(0.0), true);
-    json_schema_check(schema, &json!(1.0), false);
-    json_schema_check(schema, &json!(-1.0), false);
+#[rstest]
+#[case::zero(0.0)]
+#[case::negative(-1.0)]
+fn test_multiple_of_bad_value(#[case] value: f64) {
+    let schema = &json!({"type":"integer", "multipleOf": value});
+    json_err_test(
+        schema,
+        &format!("'multipleOf' must be a positive number, got {}", value),
+    );
 }
 
 #[rstest]
-#[case::positive_multipleof(3)]
-#[case::negative_multipleof(-3)]
-fn test_multiple_of_negative_multipleof(#[case] mult: i32) {
-    let schema = &json!({"type":"integer", "multipleOf": mult});
-    json_schema_check(schema, &json!(0), true);
-    json_schema_check(schema, &json!(3), true);
-    json_schema_check(schema, &json!(6), true);
-    json_schema_check(schema, &json!(1), false);
-    json_schema_check(schema, &json!(-1), false);
-    json_schema_check(schema, &json!(-2), false);
-    json_schema_check(schema, &json!(-3), true);
+#[case::zero(0, true)]
+#[case::one(1, false)]
+#[case::three(3, true)]
+#[case::six(6, true)]
+#[case::negative_one(-1, false)]
+#[case::negative_two(-2, false)]
+#[case::negative_three(-3, true)]
+fn test_multiple_of_int(#[case] value: i64, #[case] should_pass: bool) {
+    let schema = &json!({"type":"integer", "multipleOf": 3});
+    json_schema_check(schema, &json!(value), should_pass);
+}
+
+#[rstest]
+#[case(0.0, true)]
+#[case(0.3, true)]
+#[case(0.6, true)]
+#[case(1.0, false)]
+#[case(-1.0, false)]
+#[case(-1.2, true)]
+#[case(-0.3, true)]
+fn test_multiple_of_float(#[case] value: f64, #[case] should_pass: bool) {
+    let schema = &json!({"type":"number", "multipleOf": 0.3});
+    json_schema_check(schema, &json!(value), should_pass);
 }


### PR DESCRIPTION
Arguably, this fix could go in `derivre`, which currently only produces regexes for positive multiples. However, it's easy enough to apply the fix here

Closes #222 