### PR TITLE
support multithread compute bitmask for spec decode

### DIFF
--- a/python/llguidance/_lib.pyi
+++ b/python/llguidance/_lib.pyi
@@ -538,6 +538,21 @@ class LLExecutor:
         Prefer to use fill_next_token_bitmask_par(), which wraps this.
         """
 
+    def unsafe_compute_mask_ptr_with_draft_token(
+        self,
+        interpreters: List[Tuple[LLMatcher, int, List[int]]],
+        tgt_pointer: int,
+        one_mask_byte_size: int,
+        trg_batch_size: int,
+    ) -> None:
+        """
+        Used for speculative decoding.
+        Compute the token mask directly into memory at the specified pointer.
+        For each matcher, provide the index of the target mask and a list of draft tokens.
+        If index is K, the memory will be written at tgt_pointer + K * one_mask_byte_size,
+        where K < trg_batch_size.
+        Memory has to have size trg_batch_size * one_mask_byte_size.
+        """
 
 class JsonCompileOptions(TypedDict, total=False):
     # defaults to ","

--- a/python/llguidance/_lib.pyi
+++ b/python/llguidance/_lib.pyi
@@ -546,12 +546,28 @@ class LLExecutor:
         trg_batch_size: int,
     ) -> None:
         """
-        Used for speculative decoding.
-        Compute the token mask directly into memory at the specified pointer.
-        For each matcher, provide the index of the target mask and a list of draft tokens.
-        If index is K, the memory will be written at tgt_pointer + K * one_mask_byte_size,
-        where K < trg_batch_size.
-        Memory has to have size trg_batch_size * one_mask_byte_size.
+        Compute the token mask directly into memory at the specified pointer, including draft tokens.
+        
+        This function extends unsafe_compute_mask_ptr() to handle draft tokens in speculative decoding.
+        For each matcher in the batch, it computes masks for both the current position and all draft tokens.
+
+        Args:
+            interpreters: List of tuples containing:
+                - LLMatcher: The matcher object for constrained generation
+                - int: Index K indicating the target mask position (K < trg_batch_size)  
+                - List[int]: Draft tokens to be processed for speculative decoding
+            tgt_pointer: Memory address where mask data will be written
+            one_mask_byte_size: Size in bytes of a single token mask
+            trg_batch_size: Total batch size for memory allocation validation
+
+        Memory Layout:
+            - Main mask written at: tgt_pointer + K * one_mask_byte_size
+            - Draft token i mask written at: tgt_pointer + (K + i + 1) * one_mask_byte_size
+            - Total memory required: trg_batch_size * (spec_k + 1) * one_mask_byte_size
+
+        The function processes each matcher's draft tokens sequentially, advancing the matcher state
+        for each valid token until encountering an invalid token or termination condition.
+        State rollback is performed to maintain matcher consistency.
         """
 
 class JsonCompileOptions(TypedDict, total=False):

--- a/python/llguidance/numpy.py
+++ b/python/llguidance/numpy.py
@@ -66,3 +66,17 @@ def fill_next_token_bitmask_par(executor: LLExecutor,
     batch, vocab = bitmask.shape
     assert bitmask.flags["C_CONTIGUOUS"], "Mask must be contiguous"
     executor.unsafe_compute_mask_ptr(matchers, bitmask.ctypes.data, vocab * 4, batch)
+
+
+def fill_next_token_bitmask_par_with_draft_tokens(executor: LLExecutor,
+                                matchers: List[Tuple[LLMatcher, int, List[int]]],
+                                bitmask: NDArray[np.int32]) -> None:
+    """
+    Compute the token mask directly into the specified array.
+    For each matcher, provide the index of the target mask.
+    """
+    assert bitmask.dtype == np.int32, "Mask must be int32"
+    assert bitmask.ndim == 2, "Mask must be 2D"
+    batch, vocab = bitmask.shape
+    assert bitmask.flags["C_CONTIGUOUS"], "Mask must be contiguous"
+    executor.unsafe_compute_mask_ptr_with_draft_token(matchers, bitmask.ctypes.data, vocab * 4, batch)

--- a/python/llguidance/torch.py
+++ b/python/llguidance/torch.py
@@ -66,3 +66,14 @@ def fill_next_token_bitmask_par(executor: LLExecutor,
     assert bitmask.is_contiguous(), "Mask must be contiguous"
     executor.unsafe_compute_mask_ptr(matchers, bitmask.data_ptr(), vocab * 4,
                                      batch)
+
+
+def fill_next_token_bitmask_par_with_draft_tokens(executor: LLExecutor,
+                                matchers: List[Tuple[LLMatcher, int, List[int]]],
+                                bitmask: torch.Tensor) -> None:
+    assert bitmask.dtype == torch.int32, "Mask must be int32"
+    assert bitmask.is_cpu, "Mask must be on CPU"
+    assert bitmask.dim() == 2, "Mask must be 2D"
+    batch, vocab = bitmask.shape
+    assert bitmask.is_contiguous(), "Mask must be contiguous"
+    executor.unsafe_compute_mask_ptr_with_draft_token(matchers, bitmask.data_ptr(), vocab * 4, batch)

--- a/python_ext/src/llmatcher.rs
+++ b/python_ext/src/llmatcher.rs
@@ -100,6 +100,73 @@ impl LLExecutor {
 
         Ok(())
     }
+
+    fn unsafe_compute_mask_ptr_with_draft_token(
+        &self,
+        interpreters: Bound<'_, PyList>,
+        trg_ptr: usize,
+        one_mask_bytes: usize,
+        trg_batch_size: usize,
+        py: Python<'_>,
+    ) -> PyResult<()> {
+        if interpreters.len() == 0 {
+            return Err(PyValueError::new_err("No interpreters"));
+        }
+
+        let mut mut_refs = vec![];
+        for ent in interpreters.iter() {
+            let tupl = ent.downcast::<PyTuple>()?;
+            if tupl.len() != 3 {
+                return Err(PyValueError::new_err(
+                    "Expecting (LLMatcher, int, List[int]) tuple",
+                ));
+            }
+            let interp = tupl.get_item(0)?.extract::<PyRefMut<LLMatcher>>()?;
+            let idx = tupl.get_item(1)?.extract::<usize>()?;
+            if idx >= trg_batch_size {
+                return Err(PyValueError::new_err("Target index out of bounds"));
+            }
+            let draft_tokens = tupl.get_item(2)?.extract::<Vec<TokenId>>()?;
+            if draft_tokens.len() == 0 {
+                return Err(PyValueError::new_err("Draft tokens must not be empty"));
+            }
+            interp.validate_mask_ptr(trg_ptr, one_mask_bytes)?;
+            mut_refs.push((interp, idx, draft_tokens));
+        }
+
+        if mut_refs.len() == 1 {
+            let (mut interp, idx, draft_tokens) = mut_refs.pop().unwrap();
+            return interp.unsafe_compute_mask_ptr_with_draft_token(
+                trg_ptr + idx * one_mask_bytes,
+                one_mask_bytes,
+                draft_tokens,
+                py,
+            );
+        }
+
+        let mut_refs2: Vec<_> = mut_refs
+            .iter_mut()
+            .map(|(x, idx, draft_tokens)| (x.deref_mut(), *idx, draft_tokens.clone()))
+            .collect();
+
+        use rayon::prelude::*;
+
+        py.allow_threads(|| {
+            self.pool.install(|| {
+                mut_refs2
+                    .into_par_iter()
+                    .for_each(|(interp, idx, draft_tokens)| {
+                        interp.unsafe_compute_mask_ptr_inner_with_draft_tokens(
+                            trg_ptr + idx * one_mask_bytes,
+                            one_mask_bytes,
+                            draft_tokens,
+                        );
+                    })
+            })
+        });
+
+        Ok(())
+    }
 }
 
 impl LLMatcher {
@@ -123,6 +190,33 @@ impl LLMatcher {
             unsafe { std::slice::from_raw_parts_mut(trg_ptr as *mut u32, trg_bytes / 4) };
         let src = r.as_slice();
         trg_slice.copy_from_slice(&src[0..trg_slice.len()]);
+    }
+
+    fn unsafe_compute_mask_ptr_inner_with_draft_tokens(
+        &mut self,
+        trg_ptr: usize,
+        trg_bytes: usize,
+        draft_tokens: Vec<TokenId>,
+    ) {
+        let mut state_advancements = 0;
+        let spec_k = draft_tokens.len();
+        for token_idx in 0..=spec_k {
+            self.unsafe_compute_mask_ptr_inner(trg_ptr + token_idx * trg_bytes, trg_bytes);
+
+            if token_idx == spec_k || self.inner.is_stopped() {
+                break;
+            }
+
+            let token = draft_tokens[token_idx];
+
+            match self.inner.try_consume_tokens(&[token]) {
+                Ok(cosumed) if cosumed > 0 => state_advancements += 1,
+                _ => break,
+            }
+        }
+        if state_advancements > 0 {
+            self.rollback(state_advancements);
+        }
     }
 
     fn eos_token_set(&self) -> SimpleVob {
@@ -334,6 +428,20 @@ impl LLMatcher {
     ) -> PyResult<()> {
         self.validate_mask_ptr(trg_ptr, trg_bytes)?;
         py.allow_threads(|| self.unsafe_compute_mask_ptr_inner(trg_ptr, trg_bytes));
+        Ok(())
+    }
+
+    fn unsafe_compute_mask_ptr_with_draft_token(
+        &mut self,
+        trg_ptr: usize,
+        trg_bytes: usize,
+        draft_tokens: Vec<TokenId>,
+        py: Python<'_>,
+    ) -> PyResult<()> {
+        self.validate_mask_ptr(trg_ptr, trg_bytes)?;
+        py.allow_threads(|| {
+            self.unsafe_compute_mask_ptr_inner_with_draft_tokens(trg_ptr, trg_bytes, draft_tokens)
+        });
         Ok(())
     }
 


### PR DESCRIPTION
Support speculative decoding when we have draft tokens.

Put the parallel compute bitmask with draft tokens in the Rust Constrained Backend to avoid Python GIL.