### PR TITLE
[BUG] `force_lexeme_end` -> `try_lexeme_end` in lark lexer when out of input

### DIFF
--- a/parser/src/lark/lexer.rs
+++ b/parser/src/lark/lexer.rs
@@ -279,7 +279,7 @@ pub fn lex_lark(input: &str) -> Result<Vec<Lexeme>> {
     while idx <= input_bytes.len() {
         let mut b = b'\n';
         let res = if idx == input_bytes.len() {
-            lexer.force_lexeme_end(state)
+            lexer.try_lexeme_end(state)
         } else {
             b = input_bytes[idx];
             lexer.advance(state, b, false)

--- a/sample_parser/tests/test_lark.rs
+++ b/sample_parser/tests/test_lark.rs
@@ -211,6 +211,22 @@ fn test_lark_syntax_general() {
         "#,
         "duplicate token",
     );
+    // Unterminated regex
+    lark_err_test(
+        r#"
+        start: / "test"
+        blah: "xyz"
+    "#,
+        "lexer error",
+    );
+    // Unterminated string
+    lark_err_test(
+        r#"
+        start: "test
+        blah: "xyz"
+    "#,
+        "lexer error",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Calls `try_lexeme_end` instead of `force_lexeme_end` when we run out of input while lexing lark, avoiding a click of the ruby slippers.

@mmoskal I'd appreciate your eyes on this! My inability to get the string case to fail pre-"fix" does make me feel a little un-confident that I understood the problem correctly.

Fixes #228
