### PR TITLE
[Test] More JSON testing

### DIFF
--- a/sample_parser/tests/common_lark_utils/mod.rs
+++ b/sample_parser/tests/common_lark_utils/mod.rs
@@ -13,6 +13,12 @@ use llguidance::{
 use sample_parser::*;
 use serde_json::Value;
 
+#[derive(Debug)]
+pub enum NumericBounds {
+    Inclusive,
+    Exclusive,
+}
+
 pub fn make_parser(lark: &str, quiet: bool) -> Result<TokenParser> {
     let grm = TopLevelGrammar::from_lark(lark.to_string());
     let mut parser = get_parser_factory().create_parser_from_init(

--- a/sample_parser/tests/test_json_primitives.rs
+++ b/sample_parser/tests/test_json_primitives.rs
@@ -2,13 +2,7 @@ use rstest::*;
 use serde_json::{json, Value};
 
 mod common_lark_utils;
-use common_lark_utils::{json_err_test, json_schema_check};
-
-#[derive(Debug)]
-enum NumericBounds {
-    Inclusive,
-    Exclusive,
-}
+use common_lark_utils::{json_err_test, json_schema_check, NumericBounds};
 
 #[test]
 fn null_schema() {

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -109,6 +109,21 @@ fn allof_simple_minimum(
 }
 
 #[rstest]
+fn allof_additionalproperties(#[values(false, true)] additional_properties: bool) {
+    let schema = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {"bar": {"type": "integer"}},
+            "additionalProperties": additional_properties,
+    });
+
+    let minimal_obj = json!({"bar": 2});
+    json_schema_check(&schema, &minimal_obj, true);
+
+    let extra_obj = json!({"bar": 2, "foo": "quux"});
+    json_schema_check(&schema, &extra_obj, additional_properties == true);
+}
+
+#[rstest]
 #[case(3, false)]
 #[case(5, false)]
 #[case(9, false)]

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -166,6 +166,68 @@ fn allof_unsatisfiable() {
 }
 
 #[rstest]
+#[case(&json!("a"), false)]
+#[case(&json!("ab"), true)]
+#[case(&json!(1), false)]
+#[case(&json!(2), true)]
+fn anyof_allof_nested(#[case] value: &Value, #[case] expected_pass: bool) {
+    let schema = &json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "anyOf": [
+            {"allOf": [
+                {"type": "string"},
+                {"minLength": 2}
+            ]},
+           {"allOf": [
+                {"type": "integer"},
+                {"minimum": 2}
+            ]}
+        ]
+    });
+    json_schema_check(&schema, value, expected_pass);
+}
+
+#[rstest]
+#[case(&json!("a"), false)]
+#[case(&json!("ab"), true)]
+#[case(&json!(1), false)]
+#[case(&json!(2), true)]
+fn allof_anyof_nested(#[case] value: &Value, #[case] expected_pass: bool) {
+    let schema = &json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [
+            {"anyOf": [
+                {"type": "string"},
+                {"minimum": 2}
+            ]},
+           {"anyOf": [
+                {"type": "integer"},
+                {"minLength": 2}
+            ]}
+        ]
+    });
+    json_schema_check(&schema, value, expected_pass);
+}
+
+#[rstest]
+#[case(&json!("a"), true)]
+#[case(&json!("b"), true)]
+#[case(&json!(1), false)]
+fn anyof_one_unsatisfiable(#[case] value: &Value, #[case] expected_pass: bool) {
+    let schema = &json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "anyOf": [
+            {"allOf": [
+                {"type": "integer", "minimum": 10},
+                {"type": "integer", "maximum": 5}
+            ]},
+            {"type": "string"}
+        ]
+    });
+    json_schema_check(&schema, value, expected_pass);
+}
+
+#[rstest]
 fn allof_anyof_oneof_combined() {
     let schema = &json!({
             "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -5,7 +5,7 @@ use rstest::*;
 use serde_json::{json, Value};
 
 mod common_lark_utils;
-use common_lark_utils::{json_err_test, json_schema_check};
+use common_lark_utils::{json_err_test, json_schema_check, NumericBounds};
 
 lazy_static! {
     static ref SIMPLE_ANYOF: Value = json!({"anyOf": [
@@ -84,13 +84,26 @@ fn allof_with_base(#[case] sample: &Value, #[case] expected_pass: bool) {
 #[case(-35, false)]
 #[case(0, false)]
 #[case(29, false)]
-#[case(30, true)]
 #[case(35, true)]
 #[case(381925, true)]
-fn allof_simple_minimum(#[case] value: i32, #[case] expected_pass: bool) {
+fn allof_simple_minimum(
+    #[values(NumericBounds::Inclusive, NumericBounds::Exclusive)] bound_type_1: NumericBounds,
+    #[values(NumericBounds::Inclusive, NumericBounds::Exclusive)] bound_type_2: NumericBounds,
+    #[case] value: i32,
+    #[case] expected_pass: bool,
+) {
+    let b1_str = match bound_type_1 {
+        NumericBounds::Inclusive => "minimum",
+        NumericBounds::Exclusive => "exclusiveMinimum",
+    };
+    let b2_str = match bound_type_2 {
+        NumericBounds::Inclusive => "minimum",
+        NumericBounds::Exclusive => "exclusiveMinimum",
+    };
+
     let schema = json!({
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "allOf": [{"minimum": 30}, {"minimum": 20}],
+        "allOf": [{b1_str: 30}, {b2_str: 20}],
     });
     json_schema_check(&schema, &json!(value), expected_pass);
 }

--- a/sample_parser/tests/test_json_schema_combinations.rs
+++ b/sample_parser/tests/test_json_schema_combinations.rs
@@ -109,6 +109,21 @@ fn allof_simple_minimum(
 }
 
 #[rstest]
+#[case(3, false)]
+#[case(5, false)]
+#[case(9, false)]
+#[case(15, true)]
+#[case(20, false)]
+#[case(45, true)]
+fn allof_multipleof(#[case] value: i32, #[case] expected_pass: bool) {
+    let schema = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [{"multipleOf": 3}, {"multipleOf": 5}],
+    });
+    json_schema_check(&schema, &json!(value), expected_pass);
+}
+
+#[rstest]
 #[case("a", true)]
 #[case("b", true)]
 // Issue 224 #[case("bb", false)]


### PR DESCRIPTION
Extend the testing of JSON in the Rust layer:
- Set operations on subschema via `anyOf`, `allOf` and `oneOf` (although the last appears to need particular features enabled?)