### PR TITLE
Add option for initial skip of `%ignore` lexeme

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -318,7 +318,7 @@ MULT_NUM: %regex {
 
 Certain grammar options can be set by using `%llguidnace { ... }`,
 by passing it a JSON object with the options;
-see `LLGuidanceOptions` in [api.rs](../parser/src/api.rs#L24).
+see `LLGuidanceOptions` in [api.rs](../parser/src/api.rs#L36).
 Example: `%llguidance { "no_forcing": true }`.
 It can be specified multiple times, with the options being merged.
 

--- a/parser/src/api.rs
+++ b/parser/src/api.rs
@@ -47,6 +47,11 @@ pub struct LLGuidanceOptions {
     /// This is very unlikely what you need.
     #[serde(default)]
     pub allow_invalid_utf8: bool,
+
+    /// If set, the grammar will allow the %ignore lexeme at the start of the grammar.
+    /// Otherwise, it will only be allowed after the first non-ignored lexeme.
+    #[serde(default)]
+    pub allow_initial_skip: bool,
 }
 
 impl LLGuidanceOptions {
@@ -56,6 +61,9 @@ impl LLGuidanceOptions {
         }
         if other.allow_invalid_utf8 {
             self.allow_invalid_utf8 = true;
+        }
+        if other.allow_initial_skip {
+            self.allow_initial_skip = true;
         }
     }
 }

--- a/parser/src/grammar_builder.rs
+++ b/parser/src/grammar_builder.rs
@@ -233,6 +233,9 @@ impl GrammarBuilder {
         if options.no_forcing {
             self.regex.spec.no_forcing = true;
         }
+        if options.allow_initial_skip {
+            self.regex.spec.allow_initial_skip = true;
+        }
 
         // add root node
         self.curr_start_idx = self.new_node("start");

--- a/sample_parser/tests/test_ll.rs
+++ b/sample_parser/tests/test_ll.rs
@@ -203,6 +203,15 @@ fn test_ll_llg_options() {
         }),
         &["", "JSON‧{\"‧a‧_‧long‧_‧property‧_‧name‧\":‧ ‧5‧}"],
     );
+    check_lark_grammar(
+        r#"
+            %llguidance { "allow_initial_skip": true }
+            start: "a"*
+            IGNORED: "b"
+            %ignore IGNORED
+        "#,
+        &["", "bb‧a‧bb‧b‧aa‧a‧≺EOS≻"],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Resolves #233 by exposing an `allow_initial_skip` option