### PR TITLE
Fix build issues by adding mypy `no_site_packages` flag

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -3,3 +3,4 @@ strict = True
 files = llguidance, torch_tests
 exclude = tmp
 python_version = 3.9
+no_site_packages = True


### PR DESCRIPTION
Add `no_site_packages` flag to mypy config, allow mypy's `python_version` to reflect our minimum supported python version (3.9) while still running tests on a newer python version (3.11).

In particular, pytest (a dev dependency) recently released a version that uses pattern matching (>3.10 syntax). Without this flag, mypy will check pytest and fail.