### PR TITLE
Mark immutable pyclasses as frozen

### DIFF
--- a/python_ext/src/llmatcher.rs
+++ b/python_ext/src/llmatcher.rs
@@ -22,7 +22,7 @@ struct LLMatcher {
     tok_env: TokEnv,
 }
 
-#[pyclass]
+#[pyclass(frozen)]
 struct LLExecutor {
     pool: rayon::ThreadPool,
 }

--- a/python_ext/src/parserlimits.rs
+++ b/python_ext/src/parserlimits.rs
@@ -1,7 +1,7 @@
 use llguidance::api::ParserLimits;
 use pyo3::prelude::*;
 
-#[pyclass]
+#[pyclass(frozen)]
 pub struct LLParserLimits {
     inner: ParserLimits,
 }

--- a/python_ext/src/py.rs
+++ b/python_ext/src/py.rs
@@ -24,7 +24,7 @@ struct PyTokenizer {
 }
 
 #[derive(Clone)]
-#[pyclass]
+#[pyclass(frozen)]
 pub(crate) struct LLTokenizer {
     factory: Arc<ParserFactory>,
 }
@@ -329,7 +329,7 @@ impl TokenizerEnv for PyTokenizer {
 }
 
 #[derive(Clone)]
-#[pyclass]
+#[pyclass(frozen)]
 struct JsonCompiler {
     item_separator: String,
     key_separator: String,
@@ -393,7 +393,7 @@ fn check_grammar(grm: TopLevelGrammar, check: bool) -> PyResult<String> {
 }
 
 #[derive(Clone)]
-#[pyclass]
+#[pyclass(frozen)]
 struct LarkCompiler {}
 
 #[pymethods]
@@ -410,7 +410,7 @@ impl LarkCompiler {
 }
 
 #[derive(Clone)]
-#[pyclass]
+#[pyclass(frozen)]
 struct RegexCompiler {}
 
 #[pymethods]


### PR DESCRIPTION
See [the PyO3 docs](https://pyo3.rs/v0.27.1/class.html#frozen-classes-opting-out-of-interior-mutability) for more about the `frozen` option for the pyclass macro.

In short, it tells PyO3 that the Rust data wrapped in the class cannot be mutated via a `&mut` reference. It also makes it a compiler error to create mutable references. It's possible in the future `frozen` will become the default.

The main benefit is performance. Frozen pyclasses do not need to do any atomic reference counting when rust data gets borrowed. It also makes these types a little easier to reason about in a multithreaded context. Since all these types can be trivially marked as `frozen`, the default atomic reference counting scheme in PyO3 is unnecessary.

It's possible the other two pyclasses in the library could be marked as `frozen` as well with a little more work by leveraging some form of interior mutability.