### PR TITLE
[FIX] Coerce `Metaspace` prepend_scheme to `never`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,6 +2525,7 @@ version = "1.4.0"
 dependencies = [
  "anyhow",
  "log",
+ "rstest",
  "serde",
  "serde_json",
  "tokenizers",

--- a/toktrie_hf_tokenizers/Cargo.toml
+++ b/toktrie_hf_tokenizers/Cargo.toml
@@ -17,3 +17,6 @@ tokenizers = { version = "0.21.2", default-features = false, features = [
     "fancy-regex",
 ] }
 log = "0.4.25"
+
+[dev-dependencies]
+rstest = "0.25.0"


### PR DESCRIPTION
While we already removed any `Prepend` normalizers from huggingface tokenizers, there's an additional code-path that can still cause the prepend behavior: `Metaspace` pre-tokenizers with prepend_scheme set to `always` or `first`, e.g. as seen in Nemotron tokenizers.

Additionally ensures that `Prepend` normalizers are removed regardless of their nesting level inside (or outside) a `Sequence` normalizer.

Should fix #268