### PR TITLE
Replace deprecated maturin upload with pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -153,8 +153,8 @@ jobs:
     needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4
-      - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
         with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+          path: dist
+          merge-multiple: true
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Hard to explicitly test without publishing a new version, but the OIDC-trusted publishing should carry over. @riedgar-ms I suppose we'll hit any relevant roadblocks next time we push a version? 😅 
 
Resolves #278