### PR TITLE
Build wheels for free-threaded Python 3.14

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -80,7 +80,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist ${{ matrix.python-version == '3.12' && '--zig' || '' }}
+          args: --release --out dist ${{ matrix.python-version != '3.14t' && '--zig' || '' }}
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels


### PR DESCRIPTION
Fixes #256.

This sets up cp314t wheel builds, which requires a cp314t interpreter so I set up a build matrix to do that. It looks like maturin's `--zig` option is also incompatible, so I had to skip that option for the cp314t wheels.

The free-threaded build doesn't yet support the limited API, so supporting cp314t requires building cp314t version-specific wheels. Hopefully Python 3.15 will include a new stable ABI that will allow building free-threaded limited API wheels.

See [this build](https://github.com/ngoldbaum/llguidance/actions/runs/21959186850) from my fork. I had to temporarily enable workflow_dispatch so the commit history on the branch that actions run is based on is a little different.