### PR TITLE
fix: add fallback for token bitmask allocation when CUDA is unavailable

### DIFF
--- a/python/llguidance/torch.py
+++ b/python/llguidance/torch.py
@@ -1,7 +1,9 @@
+import logging
 from typing import Tuple, List, Union
 import torch
 from ._lib import LLMatcher, LLExecutor, LLInterpreter
 
+logger = logging.getLogger(__name__)
 
 def get_bitmask_shape(batch_size: int, vocab_size: int) -> Tuple[int, int]:
     return (batch_size, (vocab_size + 31) // 32)
@@ -16,7 +18,8 @@ def allocate_token_bitmask(batch_size: int, vocab_size: int) -> torch.Tensor:
             dtype=torch.int32,
             pin_memory=torch.cuda.is_available(),
         )
-    except Exception:
+    except RuntimeError as e:
+        logger.warning(f"Failed to pin memory: {e}. Falling back to non-pinned memory.")
         return torch.full(shape, -1, dtype=torch.int32, pin_memory=False)
 
 


### PR DESCRIPTION
In high-concurrency inference clusters, we occasionally observed a RuntimeError: No CUDA GPUs are available during the inference, despite torch.cuda.is_available() returning True. This is likely due to transient GPU or driver visibility issues.

This patch introduces a robust fallback for allocate_token_bitmask: if pinned memory allocation fails, the system will now gracefully fall back to standard host (CPU) memory, preventing a fatal engine crash.

ERROR 02-11 06:58:20 [core.py:938]   File "/usr/local/lib/python3.12/dist-packages/llguidance/torch.py", line 11, in allocate_token_bitmask
ERROR 02-11 06:58:20 [core.py:938]     return torch.full(
ERROR 02-11 06:58:20 [core.py:938]            ^^^^^^^^^^^
ERROR 02-11 06:58:20 [core.py:938] RuntimeError: No CUDA GPUs are available