### PR TITLE
Fix Linux free-threaded (cp314t) wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -98,15 +98,12 @@ jobs:
               version: '3.14t'
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python.version }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           maturin-version: ${{ env.MATURIN_VERSION }}
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --compatibility pypi ${{ matrix.python.zig && matrix.platform.zig && '--zig' || '' }}
+          args: --release --out dist --compatibility pypi -i python${{ matrix.python.version }} ${{ matrix.python.zig && matrix.platform.zig && '--zig' || '' }}
           sccache: 'true'
           manylinux: ${{ matrix.platform.manylinux }}
           before-script-linux: ${{ matrix.platform.before-script || '' }}


### PR DESCRIPTION
Linux builds run inside manylinux Docker containers, so `actions/setup-python` on the host doesn't do anything for the build -- maturin inside the container can't see it. Without an explicit `-i` flag, maturin just finds an abi3-compatible interpreter inside the container and builds an abi3 wheel, completely ignoring the matrix python version.

Here's what happened in the v1.6.0 release ([Linux 3.14t x86_64 job](https://github.com/guidance-ai/llguidance/actions/runs/22328391402/job/64606709189)):
```
🔗 Found pyo3 bindings with abi3 support
📦 Built wheel for abi3 Python ≥ 3.9 to dist/llguidance-1.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
```

vs the [macOS 3.14t aarch64 job](https://github.com/guidance-ai/llguidance/actions/runs/22328391402/job/64606709121) from the same run, where maturin runs on the host and finds the right interpreter:
```
🐍 Found CPython 3.14t at /Library/Frameworks/PythonT.framework/Versions/3.14/bin/python3
📦 Built wheel for CPython 3.14t to dist/llguidance-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl
```

Fix: pass `-i python${{ matrix.python.version }}` to maturin and drop the `setup-python` step from the Linux job. The [maturin-action docs](https://github.com/PyO3/maturin-action#manylinux-docker-container) confirm this is how you're supposed to do it for containerized builds.

cc @ngoldbaum -- this should get Linux cp314t wheels publishing. v1.6.0 is currently missing them on PyPI.
Separately, re: [your maturin issue](https://github.com/PyO3/maturin/issues/3034) -- the maintainer's response makes sense to me; the abi3 wheel there was expected and the actual riscv64 3.14t failure is a pyo3 bug, so I'll keep it excluded from the matrix