### PR TITLE
[Test] Expand JSON string format tests

### DIFF
--- a/sample_parser/tests/test_json_string_format.rs
+++ b/sample_parser/tests/test_json_string_format.rs
@@ -299,8 +299,8 @@ pub fn valid_ipv6(#[case] s: &str) {
 #[case("1:2:3:4:5:6:7")] // Test Suite: "insufficient octets without double colons"
 #[case("1")] // Test Suite: "no colons is invalid"
 #[case("1:2:3:4:5:6:7:\u{09ea}")] // Python tests: non-ASCII Bengali ৪ in last group
-             // Note: IPv4-mapped tests (e.g., ::ffff:192.168.0.1) are NOT ported — the
-             // standalone ipv6 regex does not support RFC 4291 §2.5.5 mixed notation.
+                                  // Note: IPv4-mapped tests (e.g., ::ffff:192.168.0.1) are NOT ported — the
+                                  // standalone ipv6 regex does not support RFC 4291 §2.5.5 mixed notation.
 pub fn bad_ipv6(#[case] s: &str) {
     let schema = json!({"type":"string", "format":"ipv6"});
     json_schema_check(&schema, &json!(s), false);


### PR DESCRIPTION
Expand JSON string format tests with RFC-sourced cases

- date-time: 14 valid + 14 invalid (RFC 3339 §5.8 examples, offsets, leap seconds, month boundaries)
- time: 10 valid + 13 invalid (RFC 3339 §5.6 ABNF, offsets, leap seconds, padding)
- date: 13 valid + 13 invalid (RFC 3339 §5.7 month table, all 12 month boundaries)
- duration: 12 valid + 10 invalid (ISO 8601 components, weeks, ordering)
- email: 8 valid + 7 invalid (RFC 5321 §4.1.2 dot-string, IPv4 literal)
- hostname: 8 valid + 8 invalid (RFC 1123 §2.1 label rules, length limits)
- ipv4: 6 valid + 7 invalid (octet ranges, leading zeros, netmask)
- ipv6: 10 valid + 10 invalid (RFC 4291 §2.2 compression, full form)
- uuid: 7 valid + 8 invalid (RFC 4122 §3 grouping, case, versions)

Add regex_accepts_but_invalid_* tests documenting values that the current regex incorrectly accepts (leap seconds at wrong hour/minute, non-leap-year Feb 29, hostname >253 chars). These serve as a backlog: when the regex is tightened, flip true->false and move to bad_*.

Co-authored-by: GitHub Copilot