### PR TITLE
Support \xHH escape sequences in lark string literals

### DIFF
--- a/parser/src/lark/lexer.rs
+++ b/parser/src/lark/lexer.rs
@@ -215,10 +215,10 @@ impl Token {
         (Token::Op, r"[+*?]"),
         (Token::Rule, r"!?[_?]?[a-z][_a-z0-9\-]*"),
         (Token::Token, r"_?[A-Z][_A-Z0-9\-]*"),
-        // use JSON string syntax
+        // use JSON string syntax, extended with \xHH escape sequences
         (
             Token::String,
-            r#""(\\([\"\\\/bfnrt]|u[a-fA-F0-9]{4})|[^\"\\\x00-\x1F\x7F])*"(i|)"#,
+            r#""(\\([\"\\\/bfnrt]|u[a-fA-F0-9]{4}|x[a-fA-F0-9]{2})|[^\"\\\x00-\x1F\x7F])*"(i|)"#,
         ),
         (Token::Regexp, r#"/(\\.|[^/\\])+/[imslux]*"#),
         (Token::Number, r#"[+-]?[0-9]+(\.[0-9]*)?([eE][+-]?[0-9]+)?"#),

--- a/parser/src/lark/parser.rs
+++ b/parser/src/lark/parser.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::rc::Rc;
 
 use crate::{
@@ -512,9 +513,54 @@ impl Parser {
         } else {
             (s, "")
         };
+        // Convert \xHH escape sequences to \u00HH for serde_json compatibility,
+        // since JSON only supports \uNNNN unicode escapes.
+        let inner = Self::convert_hex_escapes(inner);
         let inner =
-            serde_json::from_str(inner).map_err(|e| anyhow!("error parsing string: {e}"))?;
+            serde_json::from_str(&inner).map_err(|e| anyhow!("error parsing string: {e}"))?;
         Ok((inner, flags.to_string()))
+    }
+
+    /// Converts `\xHH` escape sequences to `\u00HH` so that serde_json can parse them.
+    /// Returns a borrowed reference when no conversion is needed (common case).
+    fn convert_hex_escapes(s: &str) -> Cow<'_, str> {
+        if !s.contains("\\x") {
+            return Cow::Borrowed(s);
+        }
+        let mut result = String::with_capacity(s.len() + s.len() / 4);
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\\' {
+                if let Some(next) = chars.next() {
+                    if next == 'x' {
+                        // Collect the two hex digits.
+                        // The lexer regex enforces exactly 2 hex digits after \x,
+                        // so the None branches below are unreachable in practice.
+                        let h1 = chars.next();
+                        let h2 = chars.next();
+                        if let (Some(d1), Some(d2)) = (h1, h2) {
+                            result.push_str("\\u00");
+                            result.push(d1);
+                            result.push(d2);
+                        } else {
+                            result.push('\\');
+                            result.push('x');
+                            if let Some(d1) = h1 {
+                                result.push(d1);
+                            }
+                        }
+                    } else {
+                        result.push('\\');
+                        result.push(next);
+                    }
+                } else {
+                    result.push('\\');
+                }
+            } else {
+                result.push(c);
+            }
+        }
+        Cow::Owned(result)
     }
 
     fn parse_simple_string(&self, string1: &str) -> Result<String> {

--- a/sample_parser/tests/test_lark.rs
+++ b/sample_parser/tests/test_lark.rs
@@ -1730,3 +1730,51 @@ fn test_parametric_long() {
         &[&s2],
     );
 }
+
+#[test]
+fn test_hex_escape_sequences() {
+    // Basic \x00 null byte matching
+    lark_str_test_many(
+        r#"start: "\x00""#,
+        &["\x00"],
+        &["a", "FINAL_REJECT:"],
+    );
+
+    // \x41 is 'A'
+    lark_str_test_many(
+        r#"start: "\x41\x42\x43""#,
+        &["ABC"],
+        &["abc", "AB"],
+    );
+
+    // Mix of \x escapes and regular characters
+    lark_str_test_many(
+        r#"start: "hello\x20world""#,
+        &["hello world"],
+        &["helloworld"],
+    );
+
+    // \x escape in token definitions
+    lark_str_test_many(
+        r#"
+            start: GREETING
+            GREETING: "hi\x21"
+        "#,
+        &["hi!"],
+        &["hi"],
+    );
+
+    // Multiple \x escapes
+    lark_str_test_many(
+        r#"start: "\x48\x49""#,
+        &["HI"],
+        &["hi", "H"],
+    );
+
+    // High-byte value: \xC0 is U+00C0 (A with grave accent), multi-byte in UTF-8
+    lark_str_test_many(
+        r#"start: "\xC0""#,
+        &["\u{00C0}"],
+        &["A", "a"],
+    );
+}


### PR DESCRIPTION
## Summary
- Add `\xHH` hex byte escape sequence support to lark grammar string literals, matching Python lark's behavior
- Extend the lexer string regex to accept `\xHH` patterns
- Add `convert_hex_escapes()` to convert `\xHH` to `\u00HH` before serde_json parsing, using `Cow<str>` to avoid allocation in the common case (no hex escapes)
- Add tests covering null bytes, ASCII chars, mixed escapes, token definitions, and high-byte values (U+0080+)

Fixes #54

## Test plan
- [ ] `cargo test -p sample_parser test_hex_escape_sequences` passes
- [ ] Existing lark tests still pass (no regression from regex change)
- [ ] `cargo clippy --all-features` clean