### PR TITLE
Fix decoding of single 0xFF byte tokens

### DIFF
--- a/parser/src/stop_controller.rs
+++ b/parser/src/stop_controller.rs
@@ -96,7 +96,7 @@ impl StopController {
             self.is_stopped = true;
         } else {
             let bytes = self.tok_env.tok_trie().token(tok_id);
-            if !bytes.is_empty() && bytes[0] == TokTrie::SPECIAL_TOKEN_MARKER {
+            if bytes.len() > 1 && bytes[0] == TokTrie::SPECIAL_TOKEN_MARKER {
                 if let Some(rx) = self.regex.as_mut() {
                     rx.state = rx.initial_state;
                 }

--- a/toktrie/src/toktree.rs
+++ b/toktrie/src/toktree.rs
@@ -483,7 +483,7 @@ impl TokTrie {
 
     pub fn token_len(&self, idx: u32) -> usize {
         let t = self.token(idx);
-        if t.is_empty() || t[0] == TokTrie::SPECIAL_TOKEN_MARKER {
+        if t.is_empty() || (t.len() > 1 && t[0] == TokTrie::SPECIAL_TOKEN_MARKER) {
             let mut idx = idx;
             let mut len = 1;
             while idx >= 10 {
@@ -519,7 +519,7 @@ impl TokTrie {
                 if include_special {
                     res.extend_from_slice(format!("<[{tok}]>").as_bytes());
                 }
-            } else if t[0] == TokTrie::SPECIAL_TOKEN_MARKER {
+            } else if t.len() > 1 && t[0] == TokTrie::SPECIAL_TOKEN_MARKER {
                 if include_special {
                     res.extend_from_slice(&t[1..]);
                 }
@@ -541,7 +541,7 @@ impl TokTrie {
         let mut res = Vec::with_capacity(tokens.len() * 6 + 32); // approximately
         for &tok in tokens {
             let t = self.token(tok);
-            if t.is_empty() || t[0] == TokTrie::SPECIAL_TOKEN_MARKER {
+            if t.is_empty() || (t.len() > 1 && t[0] == TokTrie::SPECIAL_TOKEN_MARKER) {
                 res.push(TokTrie::SPECIAL_TOKEN_MARKER);
                 res.extend_from_slice(format!("[{tok}]").as_bytes());
             } else {
@@ -577,7 +577,7 @@ impl TokTrie {
 
     pub fn is_special_token(&self, tok: TokenId) -> bool {
         let bytes = self.token(tok);
-        !bytes.is_empty() && bytes[0] == TokTrie::SPECIAL_TOKEN_MARKER
+        bytes.len() > 1 && bytes[0] == TokTrie::SPECIAL_TOKEN_MARKER
     }
 
     pub fn get_special_token(&self, name: &str) -> Option<TokenId> {

--- a/toktrie/src/toktree.rs
+++ b/toktrie/src/toktree.rs
@@ -1400,6 +1400,23 @@ mod tests {
         TokTrie::from(&info, &words)
     }
 
+    // A token whose bytes are exactly the single byte 0xFF is an ordinary byte
+    // token (the byte value 255), not a special token. Special tokens are
+    // encoded as the marker byte *followed by* a payload (e.g. `\xff[123]`), so
+    // only tokens longer than one byte that start with the marker are special.
+    // Regression coverage for decoding of single 0xFF byte tokens.
+    fn trie_with_0xff_token() -> TokTrie {
+        let mut special = vec![TokTrie::SPECIAL_TOKEN_MARKER];
+        special.extend_from_slice(b"[7]");
+        let words: Vec<Vec<u8>> = vec![
+            b"a".to_vec(),                       // 0: ordinary token
+            vec![TokTrie::SPECIAL_TOKEN_MARKER], // 1: single 0xFF byte (byte 255)
+            special,                             // 2: genuine special token (marker + payload)
+        ];
+        let info = TokRxInfo::new(words.len() as u32, 0);
+        TokTrie::from(&info, &words)
+    }
+
     #[test]
     fn test_default_single_eos() {
         let trie = make_test_trie(2);
@@ -1466,5 +1483,36 @@ mod tests {
         assert!(!set.is_allowed(0));
         assert!(!set.is_allowed(2));
         assert_eq!(set.num_set(), 2);
+    }
+
+    #[test]
+    fn single_0xff_byte_is_not_special() {
+        let trie = trie_with_0xff_token();
+        assert!(
+            !trie.is_special_token(1),
+            "a single 0xFF byte must be treated as a regular byte token"
+        );
+        assert!(
+            trie.is_special_token(2),
+            "the marker followed by a payload is a special token"
+        );
+        assert!(!trie.is_special_token(0));
+    }
+
+    #[test]
+    fn single_0xff_byte_has_byte_length() {
+        let trie = trie_with_0xff_token();
+        // Before the fix this token was treated as special and reported the
+        // synthetic `\xff[1]` length (4) instead of its real length of 1.
+        assert_eq!(trie.token(1), &[0xff]);
+        assert_eq!(trie.token_len(1), 1);
+    }
+
+    #[test]
+    fn single_0xff_byte_decodes_to_itself() {
+        let trie = trie_with_0xff_token();
+        // Before the fix `decode_raw` emitted the special-token reference
+        // `\xff[1]` instead of the literal 0xFF byte.
+        assert_eq!(trie.decode_raw(&[1]), vec![0xff]);
     }
 }


### PR DESCRIPTION
## Summary
- A token consisting of a single `0xFF` byte was incorrectly treated as a special token because the check only verified `bytes[0] == SPECIAL_TOKEN_MARKER` without confirming `len() > 1`
- Add a `len() > 1` guard to all 5 affected sites, consistent with the existing correct check in `token_dbg()`
- Affected functions: `decode_ext`, `token_len`, `decode_raw`, `is_special_token` (in `toktree.rs`) and `commit_token_u8` (in `stop_controller.rs`)

Fixes #248

## Test plan
- [ ] `cargo test` passes (no regression)
- [ ] Tokens with a single `0xFF` byte are decoded as the literal byte
- [ ] Multi-byte special tokens (e.g. `0xFF` + name) still work correctly