### PR TITLE
fix: correctly intersect patternProperties with properties and additionalProperties

### DIFF
--- a/json_schema_test_suite/expected_json_schema_test_suite.json
+++ b/json_schema_test_suite/expected_json_schema_test_suite.json
@@ -2013,7 +2013,7 @@
         "additionalProperty invalidates others": "pass",
         "additionalProperty validates others": "pass",
         "patternProperty invalidates nonproperty": "pass",
-        "patternProperty invalidates property": "false_positive",
+        "patternProperty invalidates property": "pass",
         "patternProperty validates nonproperty": "pass",
         "property invalidates property": "pass",
         "property validates property": "pass"

--- a/json_stats/expected_maskbench.json
+++ b/json_stats/expected_maskbench.json
@@ -11802,7 +11802,7 @@
     "json_error": "oneOf constraints are not supported. Enable 'coerce_one_of' option to approximate oneOf with anyOf\n  while processing https://json.schemastore.org/testenvironments.json#/definitions/config"
   },
   "JsonSchemaStore---theme.json": {
-    "json_error": "oneOf constraints are not supported. Enable 'coerce_one_of' option to approximate oneOf with anyOf"
+    "json_error": "Schema intersection stack level exceeded"
   },
   "JsonSchemaStore---tikibase.schema.json": {},
   "JsonSchemaStore---tizen_workspace.json": {},

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -382,6 +382,11 @@ impl Schema {
                 required.extend(o2.required);
 
                 let mut pattern_properties = IndexMap::new();
+                // When a pattern exists only on one side, properties matching
+                // it are "additional" from the other side's perspective and
+                // must be intersected with that side's additionalProperties.
+                let o1_ap = o1.additional_properties.schema();
+                let o2_ap = o2.additional_properties.schema();
                 for (key, prop1) in o1.pattern_properties.into_iter() {
                     if let Some(prop2) = o2.pattern_properties.get_mut(&key) {
                         let prop2 = std::mem::replace(prop2, Schema::Null);
@@ -390,14 +395,20 @@ impl Schema {
                             prop1.intersect(prop2.clone(), ctx, stack_level + 1)?,
                         );
                     } else {
-                        pattern_properties.insert(key.clone(), prop1);
+                        pattern_properties.insert(
+                            key.clone(),
+                            prop1.intersect(o2_ap.clone(), ctx, stack_level + 1)?,
+                        );
                     }
                 }
                 for (key, prop2) in o2.pattern_properties.into_iter() {
                     if pattern_properties.contains_key(&key) {
                         continue;
                     }
-                    pattern_properties.insert(key.clone(), prop2);
+                    pattern_properties.insert(
+                        key.clone(),
+                        prop2.intersect(o1_ap.clone(), ctx, stack_level + 1)?,
+                    );
                 }
 
                 let keys = pattern_properties.keys().collect::<Vec<_>>();

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -1092,6 +1092,10 @@ fn compile_object(ctx: &Context, schema: &HashMap<&str, &Value>) -> Result<Schem
     // properties schema AND any matching patternProperties schema. Since
     // gen_json_object excludes named properties from pattern property regexes,
     // we must pre-intersect here to preserve the pattern constraint.
+    //
+    // Note: the named property schema is the left operand, so when both are
+    // object or array types, the named property's sub-schema ordering takes
+    // precedence in the generated grammar.
     if !pattern_properties.is_empty() {
         for (name, prop_schema) in properties.iter_mut() {
             for (pattern, pat_schema) in pattern_properties.iter() {

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -365,7 +365,7 @@ impl Schema {
                 },
             }),
 
-            (Schema::Object(mut o1), Schema::Object(mut o2)) => {
+            (Schema::Object(mut o1), Schema::Object(o2)) => {
                 let mut properties = IndexMap::new();
                 for (key, prop1) in std::mem::take(&mut o1.properties).into_iter() {
                     let prop2 = ctx.property_schema(&o2, &key)?;
@@ -381,40 +381,14 @@ impl Schema {
                 let mut required = o1.required;
                 required.extend(o2.required);
 
-                let mut pattern_properties = IndexMap::new();
-                // When a pattern exists only on one side, properties matching
-                // it are "additional" from the other side's perspective and
-                // must be intersected with that side's additionalProperties.
-                let o1_ap = o1.additional_properties.schema();
-                let o2_ap = o2.additional_properties.schema();
-                for (key, prop1) in o1.pattern_properties.into_iter() {
-                    if let Some(prop2) = o2.pattern_properties.get_mut(&key) {
-                        let prop2 = std::mem::replace(prop2, Schema::Null);
-                        pattern_properties.insert(
-                            key.clone(),
-                            prop1.intersect(prop2.clone(), ctx, stack_level + 1)?,
-                        );
-                    } else {
-                        pattern_properties.insert(
-                            key.clone(),
-                            prop1.intersect(o2_ap.clone(), ctx, stack_level + 1)?,
-                        );
-                    }
-                }
-                for (key, prop2) in o2.pattern_properties.into_iter() {
-                    if pattern_properties.contains_key(&key) {
-                        continue;
-                    }
-                    pattern_properties.insert(
-                        key.clone(),
-                        prop2.intersect(o1_ap.clone(), ctx, stack_level + 1)?,
-                    );
-                }
-
-                let keys = pattern_properties.keys().collect::<Vec<_>>();
-                if !keys.is_empty() {
-                    ctx.check_disjoint_pattern_properties(&keys)?;
-                }
+                let pattern_properties = intersect_pattern_properties(
+                    o1.pattern_properties,
+                    o2.pattern_properties,
+                    &o1.additional_properties,
+                    &o2.additional_properties,
+                    ctx,
+                    stack_level,
+                )?;
 
                 let additional_properties =
                     match (o1.additional_properties, o2.additional_properties) {
@@ -764,6 +738,51 @@ fn define_ref(ctx: &Context, ref_uri: &str) -> Result<()> {
         ctx.insert_ref(ref_uri, resolved_schema);
     }
     Ok(())
+}
+
+/// Merge pattern properties from two object schemas during intersection.
+/// Extracted from `intersect` to keep its stack frame small for deep recursion.
+#[inline(never)]
+fn intersect_pattern_properties(
+    o1_pp: IndexMap<String, Schema>,
+    o2_pp: IndexMap<String, Schema>,
+    o1_ap: &Option<Box<Schema>>,
+    o2_ap: &Option<Box<Schema>>,
+    ctx: &Context,
+    stack_level: usize,
+) -> Result<IndexMap<String, Schema>> {
+    let mut result = IndexMap::new();
+    // When a pattern exists only on one side, properties matching
+    // it are "additional" from the other side's perspective and
+    // must be intersected with that side's additionalProperties.
+    let mut o2_remaining = o2_pp;
+    for (key, prop1) in o1_pp.into_iter() {
+        if let Some(prop2) = o2_remaining.swap_remove(&key) {
+            result.insert(key, prop1.intersect(prop2, ctx, stack_level + 1)?);
+        } else if let Some(ap) = o2_ap {
+            result.insert(
+                key,
+                prop1.intersect(ap.as_ref().clone(), ctx, stack_level + 1)?,
+            );
+        } else {
+            result.insert(key, prop1);
+        }
+    }
+    for (key, prop2) in o2_remaining.into_iter() {
+        if let Some(ap) = o1_ap {
+            result.insert(
+                key,
+                prop2.intersect(ap.as_ref().clone(), ctx, stack_level + 1)?,
+            );
+        } else {
+            result.insert(key, prop2);
+        }
+    }
+    let keys = result.keys().collect::<Vec<_>>();
+    if !keys.is_empty() {
+        ctx.check_disjoint_pattern_properties(&keys)?;
+    }
+    Ok(result)
 }
 
 fn intersect_ref(

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -1073,9 +1073,26 @@ fn compile_object(ctx: &Context, schema: &HashMap<&str, &Value>) -> Result<Schem
     let min_properties = get_usize(schema, "minProperties")?.unwrap_or(0);
     let max_properties = get_usize(schema, "maxProperties")?;
 
-    let properties = compile_prop_map(ctx, "properties", properties)?;
+    let mut properties = compile_prop_map(ctx, "properties", properties)?;
     let pattern_properties = compile_prop_map(ctx, "patternProperties", pattern_properties)?;
     ctx.check_disjoint_pattern_properties(&pattern_properties.keys().collect::<Vec<_>>())?;
+
+    // Per JSON Schema spec, a named property must validate against BOTH its
+    // properties schema AND any matching patternProperties schema. Pre-intersect
+    // here so that stage 2 (which excludes named properties from pattern regexes)
+    // produces correct constraints.
+    if !pattern_properties.is_empty() {
+        for (name, prop_schema) in properties.iter_mut() {
+            for (pattern, pat_schema) in pattern_properties.iter() {
+                if ctx.property_schema_matches(pattern, name)? {
+                    let owned = std::mem::replace(prop_schema, Schema::Null);
+                    *prop_schema = owned.intersect(pat_schema.clone(), ctx, 0)?;
+                    break; // patterns are disjoint, at most one match
+                }
+            }
+        }
+    }
+
     let additional_properties = match additional_properties {
         None => None,
         Some(val) => Some(Box::new(compile_resource(ctx, ctx.as_resource_ref(val))?)),

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -1089,9 +1089,9 @@ fn compile_object(ctx: &Context, schema: &HashMap<&str, &Value>) -> Result<Schem
     ctx.check_disjoint_pattern_properties(&pattern_properties.keys().collect::<Vec<_>>())?;
 
     // Per JSON Schema spec, a named property must validate against BOTH its
-    // properties schema AND any matching patternProperties schema. Pre-intersect
-    // here so that stage 2 (which excludes named properties from pattern regexes)
-    // produces correct constraints.
+    // properties schema AND any matching patternProperties schema. Since
+    // gen_json_object excludes named properties from pattern property regexes,
+    // we must pre-intersect here to preserve the pattern constraint.
     if !pattern_properties.is_empty() {
         for (name, prop_schema) in properties.iter_mut() {
             for (pattern, pat_schema) in pattern_properties.iter() {

--- a/parser/src/json/schema.rs
+++ b/parser/src/json/schema.rs
@@ -757,7 +757,7 @@ fn intersect_pattern_properties(
     // must be intersected with that side's additionalProperties.
     let mut o2_remaining = o2_pp;
     for (key, prop1) in o1_pp.into_iter() {
-        if let Some(prop2) = o2_remaining.swap_remove(&key) {
+        if let Some(prop2) = o2_remaining.shift_remove(&key) {
             result.insert(key, prop1.intersect(prop2, ctx, stack_level + 1)?);
         } else if let Some(ap) = o2_ap {
             result.insert(

--- a/parser/src/json/shared_context.rs
+++ b/parser/src/json/shared_context.rs
@@ -24,16 +24,16 @@ const CHECK_LIMIT: u64 = 10_000;
 
 impl PatternPropertyCache {
     pub fn is_match(&mut self, regex: &str, value: &str) -> Result<bool> {
-        if let Some(cached_regex) = self.inner.get_mut(regex) {
+        let lark_regex = regex_to_lark(regex, "dw");
+        if let Some(cached_regex) = self.inner.get_mut(lark_regex.as_str()) {
             return Ok(cached_regex.is_match(value));
         }
 
-        let regex = regex_to_lark(regex, "dw");
         let mut builder = RegexBuilder::new();
-        let eref = builder.mk_regex_for_serach(regex.as_str())?;
+        let eref = builder.mk_regex_for_serach(lark_regex.as_str())?;
         let mut rx = builder.to_regex_limited(eref, CHECK_LIMIT)?;
         let res = rx.is_match(value);
-        self.inner.insert(regex.to_string(), rx);
+        self.inner.insert(lark_regex, rx);
         Ok(res)
     }
 

--- a/parser/src/json/shared_context.rs
+++ b/parser/src/json/shared_context.rs
@@ -155,6 +155,13 @@ impl Context<'_> {
             .property_schema(obj, prop)
     }
 
+    pub fn property_schema_matches(&self, pattern: &str, name: &str) -> Result<bool> {
+        self.shared
+            .borrow_mut()
+            .pattern_cache
+            .is_match(pattern, name)
+    }
+
     pub fn check_disjoint_pattern_properties(&self, regexes: &[&String]) -> Result<()> {
         self.shared
             .borrow_mut()

--- a/sample_parser/tests/test_lark.rs
+++ b/sample_parser/tests/test_lark.rs
@@ -853,6 +853,32 @@ fn test_json_pattern_properties() {
         ],
     );
 
+    // Non-trivial intersection: "count" is declared as integer via properties,
+    // and matches "^c" pattern which requires multipleOf: 5. The intersection
+    // should produce integer ∩ multipleOf(5) = integers that are multiples of 5.
+    json_test_many(
+        &json!({
+            "type": "object",
+            "properties": {
+                "count": { "type": "integer", "minimum": 0 },
+            },
+            "patternProperties": {
+                "^c": { "type": "integer", "multipleOf": 5 },
+            },
+            "required": ["count"],
+        }),
+        &[
+            json!({"count": 0}),
+            json!({"count": 10}),
+            json!({"count": 25}),
+        ],
+        &[
+            json!({"count": 3}),
+            json!({"count": 7}),
+            json!({"count": -5}),
+        ],
+    );
+
     // Same schema but "foo" is required — since "foo" is unsatisfiable
     // (string ∩ integer), the entire schema is unsatisfiable.
     json_err_test(

--- a/sample_parser/tests/test_lark.rs
+++ b/sample_parser/tests/test_lark.rs
@@ -872,6 +872,40 @@ fn test_json_pattern_properties() {
         }),
         "required property 'foo' is unsatisfiable",
     );
+
+    // Cross-schema: patternProperties from one side must be intersected with
+    // additionalProperties from the other side. Here, the first schema says
+    // no additional properties allowed, so the pattern from the second schema
+    // becomes unsatisfiable for any matching property.
+    json_test_many(
+        &json!({
+            "allOf": [
+                { "additionalProperties": false },
+                { "patternProperties": { "^f": { "type": "integer" } } },
+            ],
+        }),
+        &[json!({})],
+        &[json!({"foo": 42}), json!({"bar": 1}), json!({"foo": 42, "bar": 1})],
+    );
+
+    // Cross-schema: one side has properties + additionalProperties: false,
+    // other side has patternProperties. The pattern must be intersected with
+    // additionalProperties: false from the first side.
+    json_test_many(
+        &json!({
+            "allOf": [
+                {
+                    "properties": { "foo": { "type": "string" } },
+                    "additionalProperties": false,
+                },
+                {
+                    "patternProperties": { "^f": { "type": "string" } },
+                },
+            ],
+        }),
+        &[json!({}), json!({"foo": "bar"})],
+        &[json!({"foo": 42}), json!({"fxx": "bar"})],
+    );
 }
 
 #[test]

--- a/sample_parser/tests/test_lark.rs
+++ b/sample_parser/tests/test_lark.rs
@@ -988,6 +988,49 @@ fn test_json_pattern_properties() {
         &[json!({}), json!({"foo": "bar"})],
         &[json!({"foo": 42}), json!({"fxx": "bar"})],
     );
+
+    // allOf: both schemas have the same pattern key "^f". The pattern schemas
+    // are intersected: integer ∩ multipleOf(3) = integers that are multiples of 3.
+    json_test_many(
+        &json!({
+            "allOf": [
+                { "patternProperties": { "^f": { "type": "integer", "minimum": 0 } } },
+                { "patternProperties": { "^f": { "type": "integer", "multipleOf": 3 } } },
+            ],
+        }),
+        &[
+            json!({}),
+            json!({"foo": 0}),
+            json!({"fox": 9}),
+            json!({"foo": 3, "fox": 6}),
+        ],
+        &[
+            json!({"foo": 1}),
+            json!({"foo": -3}),
+            json!({"foo": 3, "fox": 5}),
+        ],
+    );
+
+    // allOf: different pattern keys from each schema. Both patterns must
+    // coexist (and be disjoint).
+    json_test_many(
+        &json!({
+            "allOf": [
+                { "patternProperties": { "^f": { "type": "integer" } } },
+                { "patternProperties": { "^b": { "type": "string" } } },
+            ],
+        }),
+        &[
+            json!({}),
+            json!({"foo": 42}),
+            json!({"bar": "hello"}),
+            json!({"foo": 1, "bar": "x"}),
+        ],
+        &[
+            json!({"foo": "nope"}),
+            json!({"bar": 42}),
+        ],
+    );
 }
 
 #[test]

--- a/sample_parser/tests/test_lark.rs
+++ b/sample_parser/tests/test_lark.rs
@@ -853,9 +853,8 @@ fn test_json_pattern_properties() {
         ],
     );
 
-    // Non-trivial intersection: "count" is declared as integer via properties,
-    // and matches "^c" pattern which requires multipleOf: 5. The intersection
-    // should produce integer ∩ multipleOf(5) = integers that are multiples of 5.
+    // "count" matches both properties (integer, minimum: 0) and patternProperties
+    // "^c" (integer, multipleOf: 5). The intersection produces non-negative multiples of 5.
     json_test_many(
         &json!({
             "type": "object",
@@ -879,8 +878,8 @@ fn test_json_pattern_properties() {
         ],
     );
 
-    // Same schema but "foo" is required — since "foo" is unsatisfiable
-    // (string ∩ integer), the entire schema is unsatisfiable.
+    // "foo" is required but matches both properties (string) and patternProperties
+    // "^foo" (integer) — the intersection is unsatisfiable, so the schema errors.
     json_err_test(
         &json!({
             "type": "object",
@@ -899,9 +898,9 @@ fn test_json_pattern_properties() {
         "required property 'foo' is unsatisfiable",
     );
 
-    // Corrected version: use a named property ("name") that doesn't match
-    // any pattern, so the schema is satisfiable. Tests required properties,
-    // property ordering, and type enforcement via patternProperties + additionalProperties.
+    // "name" doesn't match any pattern, so properties + patternProperties +
+    // additionalProperties all coexist. Tests required property ordering and
+    // type enforcement across all three keyword types.
     json_test_many(
         &json!({
             "type": "object",
@@ -957,10 +956,9 @@ fn test_json_pattern_properties() {
         ],
     );
 
-    // Cross-schema: patternProperties from one side must be intersected with
-    // additionalProperties from the other side. Here, the first schema says
-    // no additional properties allowed, so the pattern from the second schema
-    // becomes unsatisfiable for any matching property.
+    // allOf: one schema has additionalProperties: false (no properties/patterns),
+    // the other has patternProperties. Since the first schema rejects all properties,
+    // the pattern becomes unsatisfiable for any matching property.
     json_test_many(
         &json!({
             "allOf": [
@@ -972,9 +970,9 @@ fn test_json_pattern_properties() {
         &[json!({"foo": 42}), json!({"bar": 1}), json!({"foo": 42, "bar": 1})],
     );
 
-    // Cross-schema: one side has properties + additionalProperties: false,
-    // other side has patternProperties. The pattern must be intersected with
-    // additionalProperties: false from the first side.
+    // allOf: one schema allows only "foo" (additionalProperties: false), the other
+    // has patternProperties "^f". Only "foo" survives (it's a named property in the
+    // first schema), while other "^f" matches like "fxx" are rejected.
     json_test_many(
         &json!({
             "allOf": [

--- a/sample_parser/tests/test_lark.rs
+++ b/sample_parser/tests/test_lark.rs
@@ -967,7 +967,11 @@ fn test_json_pattern_properties() {
             ],
         }),
         &[json!({})],
-        &[json!({"foo": 42}), json!({"bar": 1}), json!({"foo": 42, "bar": 1})],
+        &[
+            json!({"foo": 42}),
+            json!({"bar": 1}),
+            json!({"foo": 42, "bar": 1}),
+        ],
     );
 
     // allOf: one schema allows only "foo" (additionalProperties: false), the other
@@ -1026,10 +1030,7 @@ fn test_json_pattern_properties() {
             json!({"bar": "hello"}),
             json!({"foo": 1, "bar": "x"}),
         ],
-        &[
-            json!({"foo": "nope"}),
-            json!({"bar": 42}),
-        ],
+        &[json!({"foo": "nope"}), json!({"bar": 42})],
     );
 }
 

--- a/sample_parser/tests/test_lark.rs
+++ b/sample_parser/tests/test_lark.rs
@@ -800,6 +800,9 @@ fn test_json_pattern_properties() {
         "required property 'foo' is unsatisfiable",
     );
 
+    // "foo" matches patternProperties "^foo" (type: integer), but properties says
+    // type: string. Per JSON Schema spec, both must be satisfied — string ∩ integer
+    // is unsatisfiable. Since "foo" is optional, objects without "foo" are still valid.
     json_test_many(
         &json!({
             "type": "object",
@@ -817,10 +820,6 @@ fn test_json_pattern_properties() {
         &[
             json!({}),
             json!({
-                "foo": "bar"
-            }),
-            json!({
-                "foo": "bar",
                 "foo1": 123,
                 "bar": [],
                 "qux": true,
@@ -837,6 +836,9 @@ fn test_json_pattern_properties() {
         ],
         &[
             json!({
+                "foo": "bar"
+            }),
+            json!({
                 "foo": 123
             }),
             json!({
@@ -851,7 +853,9 @@ fn test_json_pattern_properties() {
         ],
     );
 
-    json_test_many(
+    // Same schema but "foo" is required — since "foo" is unsatisfiable,
+    // the entire schema is unsatisfiable.
+    json_err_test(
         &json!({
             "type": "object",
             "properties": {
@@ -866,41 +870,7 @@ fn test_json_pattern_properties() {
             },
             "required": ["foo", "mux", "foo1", "bar1"],
         }),
-        &[
-            json!({
-                "foo": "bar",
-                "mux": false,
-                "foo1": 123,
-                "bar1": [],
-            }),
-            json!({
-                "foo": "bar",
-                "mux": false,
-                "foo1": 123,
-                "bar1": [],
-                "blah": true
-            }),
-        ],
-        &[
-            json!({
-                "foo": "bar",
-                "mux": false,
-                "bar1": [],
-                "foo1": 123,
-            }),
-            json!({
-                "foo": "bar",
-                "mux": "blah",
-                "foo1": 123,
-                "bar1": [],
-            }),
-            json!({
-                "foo": "bar",
-                "mux": false,
-                "foo1": "aaa",
-                "bar1": [],
-            }),
-        ],
+        "required property 'foo' is unsatisfiable",
     );
 }
 

--- a/sample_parser/tests/test_lark.rs
+++ b/sample_parser/tests/test_lark.rs
@@ -853,8 +853,8 @@ fn test_json_pattern_properties() {
         ],
     );
 
-    // Same schema but "foo" is required — since "foo" is unsatisfiable,
-    // the entire schema is unsatisfiable.
+    // Same schema but "foo" is required — since "foo" is unsatisfiable
+    // (string ∩ integer), the entire schema is unsatisfiable.
     json_err_test(
         &json!({
             "type": "object",
@@ -871,6 +871,64 @@ fn test_json_pattern_properties() {
             "required": ["foo", "mux", "foo1", "bar1"],
         }),
         "required property 'foo' is unsatisfiable",
+    );
+
+    // Corrected version: use a named property ("name") that doesn't match
+    // any pattern, so the schema is satisfiable. Tests required properties,
+    // property ordering, and type enforcement via patternProperties + additionalProperties.
+    json_test_many(
+        &json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+            },
+            "patternProperties": {
+                "^foo": { "type": "integer" },
+                "^bar": { "type": "array" },
+            },
+            "additionalProperties": {
+                "type": "boolean",
+            },
+            "required": ["name", "mux", "foo1", "bar1"],
+        }),
+        &[
+            json!({
+                "name": "hello",
+                "mux": false,
+                "foo1": 123,
+                "bar1": [],
+            }),
+            json!({
+                "name": "hello",
+                "mux": false,
+                "foo1": 123,
+                "bar1": [],
+                "blah": true
+            }),
+        ],
+        &[
+            // wrong order
+            json!({
+                "name": "hello",
+                "mux": false,
+                "bar1": [],
+                "foo1": 123,
+            }),
+            // mux wrong type (must be boolean via additionalProperties)
+            json!({
+                "name": "hello",
+                "mux": "blah",
+                "foo1": 123,
+                "bar1": [],
+            }),
+            // foo1 wrong type (must be integer via ^foo pattern)
+            json!({
+                "name": "hello",
+                "mux": false,
+                "foo1": "aaa",
+                "bar1": [],
+            }),
+        ],
     );
 
     // Cross-schema: patternProperties from one side must be intersected with


### PR DESCRIPTION
## Summary

Fixes two bugs where `patternProperties` constraints were silently dropped:

1. **Within a schema**: A named property matching a pattern property regex was not intersected with the pattern's schema. Per the JSON Schema spec (§10.3.2), a property must validate against *both* its `properties` schema and any matching `patternProperties` schema.

2. **Across schemas** (e.g., `allOf`): When intersecting two object schemas, pattern properties that existed only on one side were carried as-is without being intersected with the other side's `additionalProperties`. From that other schema's perspective, properties matching the pattern are "additional" and must satisfy its `additionalProperties` constraint.

## Changes

- **`schema.rs`** (`compile_object`): Pre-intersect each named property with any matching pattern property schema before assembly.
- **`schema.rs`** (`intersect`): When merging pattern properties during object intersection, intersect one-sided patterns with the other side's `additionalProperties` (defaulting to `Schema::Any` if absent).
- **`shared_context.rs`**: Add `property_schema_matches` helper for regex matching.
- **`test_lark.rs`**: Comprehensive tests covering all pattern property interactions — satisfiable intersections, unsatisfiable intersections, required properties, cross-schema with `additionalProperties: false`, and same-key/different-key pattern merging via `allOf`.

## Maskbench

`JsonSchemaStore---theme.json` changes error from "oneOf constraints are not supported" to "Schema intersection stack level exceeded". The schema has 98 named properties all matching a single pattern property, each `$ref`ing the same complex definition. The pre-intersection now triggers before the oneOf check, but the schema fails to compile either way. Baseline updated.

## Test suite ratchet

1 improvement:
```
patternProperty invalidates property: false_positive → pass
```
