### PR TITLE
Fix decoder type detection for Sequence containing ByteLevel

### DIFF
--- a/toktrie_hf_tokenizers/src/lib.rs
+++ b/toktrie_hf_tokenizers/src/lib.rs
@@ -138,6 +138,8 @@ impl ByteTokenizer {
                     for decoder in decoders {
                         if decoder["type"].as_str() == Some("ByteFallback") {
                             is_byte_fallback = true;
+                        } else if decoder["type"].as_str() == Some("ByteLevel") {
+                            is_byte_level = true;
                         } else if decoder["type"].as_str() == Some("Replace")
                             && decoder["content"].as_str() == Some(" ")
                         {


### PR DESCRIPTION
Some tokenizers (e.g. https://huggingface.co/LiquidAI/LFM2.5-350M) wrap a ByteLevel decoder inside a Sequence decoder in their tokenizer.json:

```json
"decoder": {
  "type": "Sequence",
  "decoders": [
    {
      "type": "ByteLevel",
      "add_prefix_space": true,
      "trim_offsets": true,
      "use_regex": true
    }
  ]
}
```

The current code handles a top-level ByteLevel decoder and ByteFallback inside a Sequence, but not ByteLevel inside a Sequence. This causes a ValueError: can't determine decoder type when loading these tokenizers.

This PR adds a check for ByteLevel inside Sequence decoders, matching the existing pattern for ByteFallback.