### PR TITLE
[Fix] Bump derivre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "derivre"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786c7c65c4ef0c7deb05de3005e01991612a8f09fe0844fc0969c68b90468ba8"
+checksum = "0cc33bc6d9125f496c6f20a5630a1eb2c4bd435e2d5a735d39dd3232b5c14e6e"
 dependencies = [
  "ahash",
  "anyhow",

--- a/json_stats/expected_maskbench.json
+++ b/json_stats/expected_maskbench.json
@@ -5751,9 +5751,7 @@
   "Github_medium---o36797.json": {
     "json_error": "min/maxProperties only supported when all keys listed in \"properties\" are required"
   },
-  "Github_medium---o36798.json": {
-    "validation_error": "test #0: token not accepted at ⟦{\"‧kn‧x‧\":{\"‧direction‧\":{\"‧read‧\":\"‧\\\\\\⟧ * ⟦d⟧ * ⟦/‧\\\\\\‧d‧/⟧ mask: TokenSet: 13/128256; ⟨\"⟩ ⟨\",⟩ ⟨\"\\n⟩ ⟨\",\\n⟩ ⟨\"\\n\\n⟩ ⟨\",\"⟩ ⟨\",\\r\\n⟩ ⟨\"\\r\\n⟩ ⟨\"\\n\\n\\n⟩ ⟨\"\\r\\n\\r\\n⟩ ⟨\",\\n\\n⟩ ⟨\"\\n\\n\\n\\n⟩ ⟨\"\\r\\n\\r\\n\\r\\n⟩"
-  },
+  "Github_medium---o36798.json": {},
   "Github_medium---o37060.json": {},
   "Github_medium---o37086.json": {},
   "Github_medium---o37090.json": {},
@@ -10931,9 +10929,7 @@
   "JsonSchemaStore---3.0.schema.json": {
     "json_error": "oneOf constraints are not supported. Enable 'coerce_one_of' option to approximate oneOf with anyOf"
   },
-  "JsonSchemaStore---BizTalkServerApplicationSchema.json": {
-    "validation_error": "test #0: token not accepted at ⟦{\"‧Biz‧Talk‧As‧semblies‧\":[{\"‧Name‧\":\"‧b‧ts‧1‧.dll‧\",\"‧Path‧\":\"‧bins‧\\\\\\‧b‧ts‧1‧.dll⟧ * ⟦\"},{\"⟧ * ⟦Name‧\":\"‧b‧ts⟧ mask: TokenSet: 123009/128256; ALL EXCEPT EOS ⟨\"⟩ ≺HEX[a1]≻ ≺HEX[a2]≻ ≺HEX[a3]≻ ≺HEX[a4]≻ ≺HEX[a5]≻ ≺HEX[a6]≻ ≺HEX[a7]≻ ≺HEX[a8]≻ ≺HEX[a9]≻ ≺HEX[aa]≻ ≺HEX[ab]≻ ≺HEX[ac]≻ ≺HEX[ae]≻ ≺HEX[af]≻ ≺HEX[b0]≻ ≺HEX[b1]≻ ≺HEX[b2]≻ ≺HEX[b3]≻ ≺HEX[b4]≻ ≺HEX[b5]≻ ≺HEX[b6]≻ ≺HEX[b7]≻ ≺HEX[b8]≻ ≺HEX[b9]≻ ≺HEX[ba]≻ ≺HEX[bb]≻ ≺HEX[bc]≻ ≺HEX[bd]≻ ≺HEX[be]≻ ≺HEX[bf]≻ ≺HEX[c0]≻ ≺HEX[c1]≻ ≺HEX[f5]≻ ≺HEX[f6]≻ ≺HEX[f7]≻ ≺HEX[f8]≻ ≺HEX[f9]≻ ≺HEX[fa]≻ ≺HEX[fb]≻ ≺HEX[fc]≻ ≺HEX[fd]≻ ≺HEX[fe]≻ ≺HEX[ff]≻ ⟨\\0⟩ ⟨\\u{1}⟩ ⟨\\u{2}⟩ ⟨\\u{3}⟩ ⟨\\u{4}⟩ ..."
-  },
+  "JsonSchemaStore---BizTalkServerApplicationSchema.json": {},
   "JsonSchemaStore---KSP-AVC.schema.json": {
     "json_error": "Unimplemented keys: [\"uniqueItems\"]"
   },

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 toktrie = { workspace = true }
-derivre = { version = "=0.3.8", default-features = false, features = ["compress"] }
+derivre = { version = "=0.3.9", default-features = false, features = ["compress"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = { version = "1.0.138", features = ["preserve_order"] }
 anyhow = "1.0.95"

--- a/sample_parser/README.md
+++ b/sample_parser/README.md
@@ -142,6 +142,7 @@ Lark grammars allow arbitrary context-free grammars.
 | `rfc.xml` | An XML document conforming to the Lark grammar |
 | `lark.lark` | A Lark grammar that parses the Lark grammar format itself |
 | `from-llama.cpp/` | Grammar files ported from llama.cpp's GBNF format |
+| `constnewline.schema.json` | JSON schema which exposed [Issue 326](https://github.com/guidance-ai/llguidance/issues/326) |
 
 ## Key API types
 

--- a/sample_parser/data/constnewline.schema.json
+++ b/sample_parser/data/constnewline.schema.json
@@ -1,0 +1,16 @@
+{
+    "x-guidance": {
+        "whitespace_flexible": false
+    },
+    "type": "object",
+    "properties": {
+        "claudius": {
+            "type": "string",
+            "const": "Welcome, dear Rosencrantz and Guildenstern!\nMoreover that we much did long to "
+        }
+    },
+    "required": [
+        "claudius"
+    ],
+    "additionalProperties": false
+}


### PR DESCRIPTION
As described in #326 , there was a problem with long `const` strings containing escaped characters in JSON schema. This was [traced to `derivre` and fixed there](https://github.com/guidance-ai/derivre/pull/7). This PR updates `Cargo.toml` to the fixed version. As a bonus, this appears to have made a couple of `maskbench` test cases pass. 