### PR TITLE
[Build] Fix release workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -85,6 +85,7 @@ jobs:
             arch: riscv64
             zig: false
             manylinux: 2_39
+            container: 'off'
             before-script: 'sudo apt-get install -y gcc-riscv64-linux-gnu && mkdir -p ~/.cargo && printf "[target.riscv64gc-unknown-linux-gnu]\nlinker = \"riscv64-linux-gnu-gcc\"\n" >> ~/.cargo/config.toml'
         python:
           - version: '3.12'
@@ -106,6 +107,7 @@ jobs:
           args: --release --out dist --compatibility pypi -i python${{ matrix.python.version }} ${{ matrix.python.zig && matrix.platform.zig && '--zig' || '' }}
           sccache: 'true'
           manylinux: ${{ matrix.platform.manylinux }}
+          container: ${{ matrix.platform.container || '' }}
           before-script-linux: ${{ matrix.platform.before-script || '' }}
       - name: Upload wheels
         uses: actions/upload-artifact@v6

--- a/scripts/ci-publish.py
+++ b/scripts/ci-publish.py
@@ -28,9 +28,8 @@ def update_dependency(crate, version):
     """Replaces workspace refs for publishable deps in Cargo.toml.
 
     Only dependencies whose name is in PUBLISHABLE_CRATES are rewritten.
-    Other workspace references (e.g. llg_test_utils, rand) are left
-    untouched so that cargo publish correctly strips path-only
-    dev-dependencies.
+    Other workspace references (e.g. llg_test_utils) are left untouched
+    so that cargo publish correctly strips path-only dev-dependencies.
     """
     cargo_toml_path = os.path.join(crate, "Cargo.toml")
     with open(cargo_toml_path, "r") as f:

--- a/scripts/ci-publish.py
+++ b/scripts/ci-publish.py
@@ -18,40 +18,39 @@ def get_toktrie_version():
     return match.group(1)
 
 
-PUBLISHABLE_CRATES = {
-    "toktrie", "toktrie_hf_tokenizers", "toktrie_hf_downloader",
-    "toktrie_tiktoken", "llguidance",
-}
-
-
 def update_dependency(crate, version):
-    """Replaces workspace refs for publishable deps in Cargo.toml.
+    """Replaces workspace refs in [dependencies] with a version for publishing.
 
-    Only dependencies whose name is in PUBLISHABLE_CRATES are rewritten.
-    Other workspace references (e.g. llg_test_utils) are left untouched
-    so that cargo publish correctly strips path-only dev-dependencies.
+    Only rewrites ``{ workspace = true }`` lines within the [dependencies]
+    section.  Lines in [dev-dependencies] (and other sections) are left
+    untouched so that ``cargo publish`` correctly strips path-only
+    dev-dependencies.
+
+    We use simple line-by-line section tracking rather than a TOML library
+    because tomllib (stdlib) is read-only, and we want to avoid adding a
+    third-party dependency just for this script.
     """
     cargo_toml_path = os.path.join(crate, "Cargo.toml")
     with open(cargo_toml_path, "r") as f:
-        content = f.read()
+        lines = f.readlines()
 
-    def replace_if_publishable(m):
-        dep_name = m.group(1)
-        if dep_name in PUBLISHABLE_CRATES:
-            return f'{dep_name} = {{ version = "{version}" }}'
-        return m.group(0)
-
-    updated_content = re.sub(
-        r'^(\S+)\s*=\s*\{ workspace = true \}',
-        replace_if_publishable,
-        content,
-        flags=re.MULTILINE,
-    )
+    in_dependencies = False
+    workspace_re = re.compile(r'^(\S+)\s*=\s*\{ workspace = true \}')
+    updated_lines = []
+    for line in lines:
+        if line.strip().startswith("["):
+            in_dependencies = line.strip() == "[dependencies]"
+        if in_dependencies:
+            m = workspace_re.match(line)
+            if m:
+                dep_name = m.group(1)
+                line = f'{dep_name} = {{ version = "{version}" }}\n'
+        updated_lines.append(line)
 
     with open(cargo_toml_path, "w") as f:
-        f.write(updated_content)
+        f.writelines(updated_lines)
 
-    return content  # Return original content for restoration
+    return "".join(lines)  # Return original content for restoration
 
 
 def restore_dependency(crate, original_content):

--- a/scripts/ci-publish.py
+++ b/scripts/ci-publish.py
@@ -18,14 +18,36 @@ def get_toktrie_version():
     return match.group(1)
 
 
+PUBLISHABLE_CRATES = {
+    "toktrie", "toktrie_hf_tokenizers", "toktrie_hf_downloader",
+    "toktrie_tiktoken", "llguidance",
+}
+
+
 def update_dependency(crate, version):
-    """Replaces `workspace = true` dependency in Cargo.toml with actual version."""
+    """Replaces workspace refs for publishable deps in Cargo.toml.
+
+    Only dependencies whose name is in PUBLISHABLE_CRATES are rewritten.
+    Other workspace references (e.g. llg_test_utils, rand) are left
+    untouched so that cargo publish correctly strips path-only
+    dev-dependencies.
+    """
     cargo_toml_path = os.path.join(crate, "Cargo.toml")
     with open(cargo_toml_path, "r") as f:
         content = f.read()
 
-    updated_content = re.sub(r'\{ workspace = true \}',
-                             f'{{ version = "{version}" }}', content)
+    def replace_if_publishable(m):
+        dep_name = m.group(1)
+        if dep_name in PUBLISHABLE_CRATES:
+            return f'{dep_name} = {{ version = "{version}" }}'
+        return m.group(0)
+
+    updated_content = re.sub(
+        r'^(\S+)\s*=\s*\{ workspace = true \}',
+        replace_if_publishable,
+        content,
+        flags=re.MULTILINE,
+    )
 
     with open(cargo_toml_path, "w") as f:
         f.write(updated_content)


### PR DESCRIPTION
Our last release failed with a couple of errors. Turn CoPilot loose on them.

`ci-publish.py`: only rewrite workspace refs for in 'dependencies' so that path-only dev-dependencies (`llg_test_utils` was the triggering crate here) are left untouched and correctly stripped by cargo publish.

`wheels.yml`: disable Docker container for riscv64 target to avoid exec format error from running a linux/riscv64 image on an amd64 runner. Cross-compilation uses the host-installed cross-compiler instead.