### PR TITLE
Refactor decoder detection to use enum matching with recursive traversal

### DIFF
--- a/toktrie_hf_tokenizers/src/lib.rs
+++ b/toktrie_hf_tokenizers/src/lib.rs
@@ -564,13 +564,16 @@ mod tests {
     }
 
     #[rstest]
-    #[case::byte_level_top_level(r#"{
+    #[case::byte_level_top_level(
+        r#"{
         "type": "ByteLevel",
         "add_prefix_space": false,
         "trim_offsets": true,
         "use_regex": true
-    }"#)]
-    #[case::byte_level_in_sequence(r#"{
+    }"#
+    )]
+    #[case::byte_level_in_sequence(
+        r#"{
         "type": "Sequence",
         "decoders": [{
             "type": "ByteLevel",
@@ -578,17 +581,22 @@ mod tests {
             "trim_offsets": true,
             "use_regex": true
         }]
-    }"#)]
-    #[case::byte_fallback_top_level(r#"{
+    }"#
+    )]
+    #[case::byte_fallback_top_level(
+        r#"{
         "type": "ByteFallback"
-    }"#)]
-    #[case::byte_fallback_in_sequence(r#"{
+    }"#
+    )]
+    #[case::byte_fallback_in_sequence(
+        r#"{
         "type": "Sequence",
         "decoders": [
             { "type": "ByteFallback" },
             { "type": "Fuse" }
         ]
-    }"#)]
+    }"#
+    )]
     fn test_decoder_detection(#[case] decoder: &str) {
         let tokenizer_json = format!(
             r#"{{
@@ -620,7 +628,6 @@ mod tests {
         );
 
         let hf_tokenizer = Tokenizer::from_str(&tokenizer_json).unwrap();
-        ByteTokenizer::from_tokenizer(hf_tokenizer)
-            .expect("decoder type should be detected");
+        ByteTokenizer::from_tokenizer(hf_tokenizer).expect("decoder type should be detected");
     }
 }

--- a/toktrie_hf_tokenizers/src/lib.rs
+++ b/toktrie_hf_tokenizers/src/lib.rs
@@ -134,31 +134,32 @@ impl ByteTokenizer {
             is_byte_fallback: &mut bool,
             is_byte_level: &mut bool,
             space_ch: &mut char,
-        ) {
+        ) -> Result<()> {
             match d {
                 DecoderWrapper::ByteFallback(_) => *is_byte_fallback = true,
                 DecoderWrapper::ByteLevel(_) => *is_byte_level = true,
                 DecoderWrapper::Replace(r) if r.content == " " => {
                     // Replace.pattern is private with no accessor, so serialize to extract it
-                    let v = serde_json::to_value(r).unwrap();
+                    let v = serde_json::to_value(r)?;
                     if let Some(s) = v["pattern"]["String"].as_str() {
-                        let chars: Vec<char> = s.chars().collect();
-                        if chars.len() == 1 {
-                            *space_ch = chars[0];
+                        let mut chars = s.chars();
+                        if let (Some(ch), None) = (chars.next(), chars.next()) {
+                            *space_ch = ch;
                         }
                     }
                 }
                 DecoderWrapper::Sequence(seq) => {
                     for d in seq.get_decoders() {
-                        check_decoder(d, is_byte_fallback, is_byte_level, space_ch);
+                        check_decoder(d, is_byte_fallback, is_byte_level, space_ch)?;
                     }
                 }
                 _ => {}
             }
+            Ok(())
         }
 
         if let Some(d) = hft.get_decoder() {
-            check_decoder(d, &mut is_byte_fallback, &mut is_byte_level, &mut space_ch);
+            check_decoder(d, &mut is_byte_fallback, &mut is_byte_level, &mut space_ch)?;
         }
 
         if !is_byte_fallback && !is_byte_level {
@@ -597,6 +598,18 @@ mod tests {
         ]
     }"#
     )]
+    #[case::byte_fallback_in_nested_sequence(
+        r#"{
+        "type": "Sequence",
+        "decoders": [{
+            "type": "Sequence",
+            "decoders": [
+                { "type": "ByteFallback" },
+                { "type": "Fuse" }
+            ]
+        }]
+    }"#
+    )]
     fn test_decoder_detection(#[case] decoder: &str) {
         let tokenizer_json = format!(
             r#"{{
@@ -629,5 +642,68 @@ mod tests {
 
         let hf_tokenizer = Tokenizer::from_str(&tokenizer_json).unwrap();
         ByteTokenizer::from_tokenizer(hf_tokenizer).expect("decoder type should be detected");
+    }
+
+    #[rstest]
+    #[case::replace_space_top_level(
+        r#"{
+        "type": "Sequence",
+        "decoders": [
+            { "type": "ByteFallback" },
+            { "type": "Replace", "pattern": { "String": "▁" }, "content": " " },
+            { "type": "Fuse" }
+        ]
+    }"#
+    )]
+    #[case::replace_space_in_nested_sequence(
+        r#"{
+        "type": "Sequence",
+        "decoders": [{
+            "type": "Sequence",
+            "decoders": [
+                { "type": "ByteFallback" },
+                { "type": "Replace", "pattern": { "String": "▁" }, "content": " " },
+                { "type": "Fuse" }
+            ]
+        }]
+    }"#
+    )]
+    fn test_decoder_space_char(#[case] decoder: &str) {
+        let tokenizer_json = format!(
+            r#"{{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [],
+            "normalizer": null,
+            "pre_tokenizer": {{
+                "type": "ByteLevel",
+                "add_prefix_space": false,
+                "trim_offsets": true
+            }},
+            "post_processor": null,
+            "decoder": {decoder},
+            "model": {{
+                "type": "BPE",
+                "dropout": null,
+                "unk_token": null,
+                "continuing_subword_prefix": "",
+                "end_of_word_suffix": "",
+                "fuse_unk": false,
+                "vocab": {{
+                    "▁hello": 0
+                }},
+                "merges": []
+            }}
+        }}"#
+        );
+
+        let hf_tokenizer = Tokenizer::from_str(&tokenizer_json).unwrap();
+        let bt =
+            ByteTokenizer::from_tokenizer(hf_tokenizer).expect("decoder type should be detected");
+        assert_eq!(
+            bt.token_bytes[0], b" hello",
+            "space_ch replacement should convert ▁ to space"
+        );
     }
 }

--- a/toktrie_hf_tokenizers/src/lib.rs
+++ b/toktrie_hf_tokenizers/src/lib.rs
@@ -562,4 +562,65 @@ mod tests {
         let after_ids = after_encoded.get_ids();
         assert_eq!(after_ids, vec![2, 3], "After fix: expected [a, >]");
     }
+
+    #[rstest]
+    #[case::byte_level_top_level(r#"{
+        "type": "ByteLevel",
+        "add_prefix_space": false,
+        "trim_offsets": true,
+        "use_regex": true
+    }"#)]
+    #[case::byte_level_in_sequence(r#"{
+        "type": "Sequence",
+        "decoders": [{
+            "type": "ByteLevel",
+            "add_prefix_space": false,
+            "trim_offsets": true,
+            "use_regex": true
+        }]
+    }"#)]
+    #[case::byte_fallback_top_level(r#"{
+        "type": "ByteFallback"
+    }"#)]
+    #[case::byte_fallback_in_sequence(r#"{
+        "type": "Sequence",
+        "decoders": [
+            { "type": "ByteFallback" },
+            { "type": "Fuse" }
+        ]
+    }"#)]
+    fn test_decoder_detection(#[case] decoder: &str) {
+        let tokenizer_json = format!(
+            r#"{{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [],
+            "normalizer": null,
+            "pre_tokenizer": {{
+                "type": "ByteLevel",
+                "add_prefix_space": false,
+                "trim_offsets": true
+            }},
+            "post_processor": null,
+            "decoder": {decoder},
+            "model": {{
+                "type": "BPE",
+                "dropout": null,
+                "unk_token": null,
+                "continuing_subword_prefix": "",
+                "end_of_word_suffix": "",
+                "fuse_unk": false,
+                "vocab": {{
+                    "a": 0
+                }},
+                "merges": []
+            }}
+        }}"#
+        );
+
+        let hf_tokenizer = Tokenizer::from_str(&tokenizer_json).unwrap();
+        ByteTokenizer::from_tokenizer(hf_tokenizer)
+            .expect("decoder type should be detected");
+    }
 }

--- a/toktrie_hf_tokenizers/src/lib.rs
+++ b/toktrie_hf_tokenizers/src/lib.rs
@@ -9,7 +9,9 @@ use std::{
     path::Path,
     sync::Arc,
 };
-use tokenizers::{normalizers, pre_tokenizers, NormalizerWrapper, PreTokenizerWrapper, Tokenizer};
+use tokenizers::{
+    normalizers, pre_tokenizers, DecoderWrapper, NormalizerWrapper, PreTokenizerWrapper, Tokenizer,
+};
 use toktrie::{TokEnv, TokRxInfo, TokTrie, TokenId, TokenizerEnv};
 
 /// A HuggingFace tokenizer adapted for byte-level token processing.
@@ -127,32 +129,36 @@ impl ByteTokenizer {
             hft.with_pre_tokenizer(Some(fix_metaspace(pt)));
         }
 
-        if let Some(d) = hft.get_decoder() {
-            // DecoderWrapper::Sequence() doesn't let one access the decoders
-            // so we resort to json munching
-            let v = serde_json::to_value(d).unwrap();
-            if v["type"].as_str() == Some("ByteLevel") {
-                is_byte_level = true;
-            } else if v["type"].as_str() == Some("Sequence") {
-                if let Some(decoders) = v["decoders"].as_array() {
-                    for decoder in decoders {
-                        if decoder["type"].as_str() == Some("ByteFallback") {
-                            is_byte_fallback = true;
-                        } else if decoder["type"].as_str() == Some("ByteLevel") {
-                            is_byte_level = true;
-                        } else if decoder["type"].as_str() == Some("Replace")
-                            && decoder["content"].as_str() == Some(" ")
-                        {
-                            if let Some(s) = decoder["pattern"]["String"].as_str() {
-                                let s: Vec<char> = s.chars().collect();
-                                if s.len() == 1 {
-                                    space_ch = s[0];
-                                }
-                            }
+        fn check_decoder(
+            d: &DecoderWrapper,
+            is_byte_fallback: &mut bool,
+            is_byte_level: &mut bool,
+            space_ch: &mut char,
+        ) {
+            match d {
+                DecoderWrapper::ByteFallback(_) => *is_byte_fallback = true,
+                DecoderWrapper::ByteLevel(_) => *is_byte_level = true,
+                DecoderWrapper::Replace(r) if r.content == " " => {
+                    // Replace.pattern is private with no accessor, so serialize to extract it
+                    let v = serde_json::to_value(r).unwrap();
+                    if let Some(s) = v["pattern"]["String"].as_str() {
+                        let chars: Vec<char> = s.chars().collect();
+                        if chars.len() == 1 {
+                            *space_ch = chars[0];
                         }
                     }
                 }
+                DecoderWrapper::Sequence(seq) => {
+                    for d in seq.get_decoders() {
+                        check_decoder(d, is_byte_fallback, is_byte_level, space_ch);
+                    }
+                }
+                _ => {}
             }
+        }
+
+        if let Some(d) = hft.get_decoder() {
+            check_decoder(d, &mut is_byte_fallback, &mut is_byte_level, &mut space_ch);
         }
 
         if !is_byte_fallback && !is_byte_level {


### PR DESCRIPTION
Refactors the decoder type detection logic in `ByteTokenizer::from_tokenizer` to use proper `DecoderWrapper` enum matching instead of serializing to JSON and string-matching on type tags.

This brings the decoder handling in line with how the normalizer (`remove_prepend_normalizer`) and pre-tokenizer (`fix_metaspace`) already work — a recursive function that handles individual variants and traverses into `Sequence` wrappers.

Refactoring:
- Replace JSON munching with a `check_decoder` function that pattern-matches on `DecoderWrapper` variants
- Use `Sequence::get_decoders()` to traverse children (the old comment claiming this wasn't possible was outdated)
- JSON serialization is retained only for `Replace.pattern`, which has no public accessor

Behavioral changes:
- `ByteFallback` and `Replace` (space char) are now detected at the root level, not only inside a `Sequence`
- Nested `Sequence` decoders are handled recursively instead of only one level deep

Note: builds on #325 by @nathanrchn 