### PR TITLE
Bump derivre to 0.3.10 (big-endian fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "derivre"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc33bc6d9125f496c6f20a5630a1eb2c4bd435e2d5a735d39dd3232b5c14e6e"
+checksum = "242fdcaa7ed2a72ad6c19191aaaa66a9497653b376ae890c604a2ba70006d0cf"
 dependencies = [
  "ahash",
  "anyhow",

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 toktrie = { workspace = true }
-derivre = { version = "=0.3.9", default-features = false, features = ["compress"] }
+derivre = { version = "=0.3.10", default-features = false, features = ["compress"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = { version = "1.0.138", features = ["preserve_order"] }
 anyhow = "1.0.95"


### PR DESCRIPTION
Bumps derivre from 0.3.9 to 0.3.10, which includes a fix for `Expr::Byte` serialization on big-endian platforms (https://github.com/guidance-ai/derivre/pull/10).

Possibly addresses #330.