### PR TITLE
Add llg_get_version() binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "derivre"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242fdcaa7ed2a72ad6c19191aaaa66a9497653b376ae890c604a2ba70006d0cf"
+checksum = "dd3bf7087923a80510e6ea986960cb4011bcf54259ecb19a80bf40a645a1526c"
 dependencies = [
  "ahash",
  "anyhow",

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 toktrie = { workspace = true }
-derivre = { version = "=0.3.10", default-features = false, features = ["compress"] }
+derivre = { version = "=0.3.11", default-features = false, features = ["compress"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = { version = "1.0.138", features = ["preserve_order"] }
 anyhow = "1.0.95"

--- a/parser/llguidance.h
+++ b/parser/llguidance.h
@@ -819,6 +819,16 @@ int32_t llg_matcher_compute_ff_tokens(struct LlgMatcher *matcher,
  */
 struct LlgMatcher *llg_clone_matcher(const struct LlgMatcher *matcher);
 
+/**
+ * Returns the version string of llguidance and its key dependencies.
+ * This also allows dumping the version of the binary using
+ * `strings libllguidance.so | grep -oE "(llguidance|derivre)@[0-9.]+"`
+ *
+ * The returned pointer is valid for the lifetime of the process and must not
+ * be freed by the caller.
+ */
+const char *llg_get_version(void);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/parser/src/ffi.rs
+++ b/parser/src/ffi.rs
@@ -1600,3 +1600,21 @@ pub extern "C" fn llg_clone_matcher(matcher: &LlgMatcher) -> *mut LlgMatcher {
         tok_env: matcher.tok_env.clone(),
     }))
 }
+
+/// Returns the version string of llguidance and its key dependencies.
+/// This also allows dumping the version of the binary using
+/// `strings libllguidance.so | grep -oE "(llguidance|derivre)@[0-9.]+"`
+///
+/// The returned pointer is valid for the lifetime of the process and must not
+/// be freed by the caller.
+#[no_mangle]
+pub extern "C" fn llg_get_version() -> *const c_char {
+    // Both version tags are compile-time literals so they're findable via `strings`.
+    static LLG_VERSION: &str = concat!("llguidance@", env!("CARGO_PKG_VERSION"));
+    static VERSION: std::sync::OnceLock<std::ffi::CString> = std::sync::OnceLock::new();
+    VERSION
+        .get_or_init(|| {
+            std::ffi::CString::new(format!("{} {}", LLG_VERSION, derivre::VERSION)).unwrap()
+        })
+        .as_ptr()
+}

--- a/python/llguidance/__init__.py
+++ b/python/llguidance/__init__.py
@@ -14,6 +14,10 @@ from ._tokenizer import TokenizerWrapper
 from ._grammar_from import GrammarFormat, grammar_from
 from ._struct_tag import StructTag
 
+from importlib.metadata import version as _pkg_version
+
+__version__ = _pkg_version("llguidance")
+
 __all__ = [
     "LLTokenizer",
     "LLMatcher",
@@ -29,4 +33,5 @@ __all__ = [
     "StructTag",
     "regex_to_lark",
     "get_version",
+    "__version__",
 ]

--- a/python/llguidance/__init__.py
+++ b/python/llguidance/__init__.py
@@ -8,6 +8,7 @@ from ._lib import (
     LLMatcher,
     LLParserLimits,
     regex_to_lark,
+    get_version,
 )
 from ._tokenizer import TokenizerWrapper
 from ._grammar_from import GrammarFormat, grammar_from
@@ -27,4 +28,5 @@ __all__ = [
     "GrammarFormat",
     "StructTag",
     "regex_to_lark",
+    "get_version",
 ]

--- a/python/llguidance/_lib.pyi
+++ b/python/llguidance/_lib.pyi
@@ -715,3 +715,6 @@ def regex_to_lark(regex: str, use_ascii: str = "d") -> str:
     For Python2 or byte patters in Python3 semantics `use_ascii = "dws"`
     More flags may be added in future.
     """
+
+def get_version() -> str:
+    """Returns the version string of llguidance and its key dependencies."""

--- a/python_ext/src/py.rs
+++ b/python_ext/src/py.rs
@@ -484,12 +484,23 @@ fn regex_to_lark(regex: &str, use_ascii: Option<&str>) -> String {
     llguidance::regex_to_lark(regex, use_ascii.unwrap_or(""))
 }
 
+/// Returns the version string of llguidance and its key dependencies.
+#[pyfunction]
+fn get_version() -> String {
+    format!(
+        "llguidance@{} {}",
+        env!("CARGO_PKG_VERSION"),
+        llguidance::derivre::VERSION
+    )
+}
+
 pub(crate) fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<LLTokenizer>()?;
     m.add_class::<JsonCompiler>()?;
     m.add_class::<LarkCompiler>()?;
     m.add_class::<RegexCompiler>()?;
     m.add_function(wrap_pyfunction!(regex_to_lark, m)?)?;
+    m.add_function(wrap_pyfunction!(get_version, m)?)?;
     Ok(())
 }
 


### PR DESCRIPTION
Adds a binding to dump the llguidance version, along with key dependency versions. Adding this binding also makes sure the version itself is stored as a string in the built binary files, so we can dump it using `strings` later on.

This change depends on the following derivre PR: https://github.com/guidance-ai/derivre/pull/11