### PR TITLE
Fix big endianess issue for llguidance

### DIFF
--- a/python_ext/src/llinterpreter.rs
+++ b/python_ext/src/llinterpreter.rs
@@ -135,12 +135,7 @@ impl LLInterpreter {
         let r = self.inner.compute_mask().map_err(val_error)?;
         let trg_slice = unsafe { trg.as_bytes_mut() };
         if let Some(m) = r.sample_mask.as_ref() {
-            let src = bytemuck::cast_slice::<u32, u8>(m.as_slice());
-            if trg_slice.len() > src.len() {
-                trg_slice[..src.len()].copy_from_slice(src);
-            } else {
-                trg_slice.copy_from_slice(&src[..trg_slice.len()]);
-            }
+            llguidance::toktrie::bytes::write_u32s_as_le_bytes(m.as_slice(), trg_slice);
         } else {
             trg_slice.fill(0);
         };

--- a/python_ext/src/llmatcher.rs
+++ b/python_ext/src/llmatcher.rs
@@ -515,7 +515,10 @@ impl LLMatcher {
     fn compute_bitmask(&mut self, py: Python<'_>) -> Cow<'_, [u8]> {
         py.detach(|| {
             let m = self.compute_mask_or_eos();
-            Cow::Owned(bytemuck::cast_slice(m.as_slice()).to_vec())
+            let words = m.as_slice();
+            let mut bytes = vec![0u8; words.len() * 4];
+            llguidance::toktrie::bytes::write_u32s_as_le_bytes(words, &mut bytes);
+            Cow::Owned(bytes)
         })
     }
 

--- a/toktrie/src/bytes.rs
+++ b/toktrie/src/bytes.rs
@@ -13,6 +13,25 @@ pub fn clone_vec_as_bytes<T: NoUninit>(input: &[T]) -> Vec<u8> {
     bytemuck::cast_slice(input).to_vec()
 }
 
+/// Write `&[u32]` into `&mut [u8]` in little-endian byte order.
+/// This is safe to call on any platform and guarantees a consistent
+/// byte layout regardless of native endianness.
+///
+/// If `dst` is shorter than `words.len() * 4`, only the bytes that fit
+/// are written (the trailing partial word is truncated).
+/// If `dst` is longer than `words.len() * 4`, the extra bytes are left
+/// untouched.
+pub fn write_u32s_as_le_bytes(words: &[u32], dst: &mut [u8]) {
+    for (i, &w) in words.iter().enumerate() {
+        let start = i * 4;
+        let end = (start + 4).min(dst.len());
+        if start >= dst.len() {
+            break;
+        }
+        dst[start..end].copy_from_slice(&w.to_le_bytes()[..end - start]);
+    }
+}
+
 pub fn vec_from_bytes<T: PodTrait>(bytes: &[u8]) -> Vec<T> {
     if !bytes.len().is_multiple_of(size_of::<T>()) {
         panic!(
@@ -148,5 +167,41 @@ mod tests {
     fn test_very_small_limit() {
         let result = limit_display("hello", 1);
         assert_eq!(result, "h...");
+    }
+
+    #[test]
+    fn test_write_u32s_exact_fit() {
+        let words: &[u32] = &[0xDEADBEEF, 0x01020304];
+        let mut buf = [0u8; 8];
+        write_u32s_as_le_bytes(words, &mut buf);
+        assert_eq!(buf, [0xEF, 0xBE, 0xAD, 0xDE, 0x04, 0x03, 0x02, 0x01]);
+    }
+
+    #[test]
+    fn test_write_u32s_dst_shorter_truncates() {
+        let words: &[u32] = &[0xDEADBEEF, 0x01020304];
+        let mut buf = [0u8; 5];
+        write_u32s_as_le_bytes(words, &mut buf);
+        // first word fully written, second word truncated to 1 byte
+        assert_eq!(buf, [0xEF, 0xBE, 0xAD, 0xDE, 0x04]);
+    }
+
+    #[test]
+    fn test_write_u32s_dst_longer_leaves_tail() {
+        let words: &[u32] = &[0x00000001];
+        let mut buf = [0xFF; 8];
+        write_u32s_as_le_bytes(words, &mut buf);
+        assert_eq!(buf, [0x01, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn test_write_u32s_empty_inputs() {
+        let mut buf = [0xAA; 4];
+        write_u32s_as_le_bytes(&[], &mut buf);
+        assert_eq!(buf, [0xAA; 4]);
+
+        let words: &[u32] = &[0x12345678];
+        let mut empty_buf: [u8; 0] = [];
+        write_u32s_as_le_bytes(words, &mut empty_buf);
     }
 }

--- a/toktrie/src/svob.rs
+++ b/toktrie/src/svob.rs
@@ -227,7 +227,7 @@ impl SimpleVob {
 
     pub fn write_to(&self, buf: &mut [u8]) {
         assert!(buf.len() <= self.data.len() * (BITS / 8));
-        buf.copy_from_slice(&bytemuck::cast_slice(&self.data)[..buf.len()]);
+        crate::bytes::write_u32s_as_le_bytes(&self.data, buf);
     }
 
     #[inline(always)]

--- a/toktrie/tests/test_svob.rs
+++ b/toktrie/tests/test_svob.rs
@@ -219,11 +219,10 @@ fn test_write_to() {
     // write out first two u32's
     let mut buf = [0u8; 8];
     v.write_to(&mut buf);
-    let words: &[u32] = bytemuck::cast_slice(&buf);
-    // first word should be 0xffffffff if the first 32 bits are set
-    assert_eq!(words[0], 0xffffffff);
-    // second word should be 0 (no bits set from 32..64)
-    assert_eq!(words[1], 0);
+    let w0 = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+    let w1 = u32::from_le_bytes(buf[4..8].try_into().unwrap());
+    assert_eq!(w0, 0xffffffff);
+    assert_eq!(w1, 0);
 }
 
 #[test]


### PR DESCRIPTION
Fix `compute_bitmask()`, `compute_mask_into()`, and `SimpleVob::write_to()` to always produce little-endian bytes, ensuring consistent cross-platform behavior on big-endian architectures like s390x 

On s390x, three APIs that serialize the internal `u32` bitmask to `&[u8]` used `bytemuck::cast_slice`, which produces **platform-native** byte order. Consumers of these byte streams (Python code, tests) assume little-endian layout, causing bit positions to be misinterpreted on s390x.

Fixes #330 