### PR TITLE
Pin Rust toolchain to 1.95.0 via rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Pins rust toolchain version using rust-toolchain.toml as documented here:

https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

Components selected from what the CI uses:

 - clippy: lint.yml runs cargo clippy
 - rustfmt: lint.yml runs cargo fmt --check