### PR TITLE
[Build] New workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,235 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+  PYTHON_VERSION: '3.12'
+  MATURIN_VERSION: 'v1.11.5'
+
+# ===========================================================================
+# Phase 1 — Validate
+# ===========================================================================
+jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yml
+    with:
+      ref: ${{ github.sha }}
+
+  rust-tests:
+    name: Rust Tests (${{ matrix.profile }})
+    uses: ./.github/workflows/rust-tests.yml
+    strategy:
+      matrix:
+        profile: [debug, release]
+    with:
+      profile: ${{ matrix.profile }}
+      ref: ${{ github.sha }}
+
+  python-tests:
+    name: Python Tests
+    uses: ./.github/workflows/python-tests.yml
+    with:
+      python-version: '3.12'
+      ref: ${{ github.sha }}
+
+# ===========================================================================
+# Phase 2 — Build (depends on all validation passing)
+# ===========================================================================
+  sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    needs: [lint, rust-tests, python-tests]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          command: sdist
+          args: --out dist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-sdist
+          path: dist
+
+  linux:
+    name: Build Linux (${{ matrix.platform.arch }}, py${{ matrix.python.version }})
+    runs-on: ${{ matrix.platform.runner }}
+    needs: [lint, rust-tests, python-tests]
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            arch: x86_64
+            zig: true
+            manylinux: auto
+          - runner: ubuntu-latest
+            target: i686-unknown-linux-gnu
+            arch: x86
+            zig: true
+            manylinux: auto
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            arch: aarch64
+            zig: true
+            manylinux: auto
+          - runner: ubuntu-latest
+            target: riscv64gc-unknown-linux-gnu
+            arch: riscv64
+            zig: false
+            manylinux: 2_39
+            container: 'off'
+            before-script: >-
+              sudo apt-get install -y gcc-riscv64-linux-gnu &&
+              mkdir -p ~/.cargo &&
+              printf "[target.riscv64gc-unknown-linux-gnu]\nlinker = \"riscv64-linux-gnu-gcc\"\n" >> ~/.cargo/config.toml
+        python:
+          - version: '3.12'
+            zig: true
+          - version: '3.14t'
+            zig: false
+        exclude:
+          - platform:
+              arch: riscv64
+            python:
+              version: '3.14t'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --compatibility pypi -i python${{ matrix.python.version }} ${{ matrix.python.zig && matrix.platform.zig && '--zig' || '' }}
+          sccache: 'true'
+          manylinux: ${{ matrix.platform.manylinux }}
+          container: ${{ matrix.platform.container || '' }}
+          before-script-linux: ${{ matrix.platform.before-script || '' }}
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-linux-${{ matrix.platform.arch }}-${{ matrix.python.version }}
+          path: dist
+
+  windows:
+    name: Build Windows (${{ matrix.platform.target }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.platform.runner }}
+    needs: [lint, rust-tests, python-tests]
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            target: x64
+          - runner: windows-latest
+            target: x86
+        python-version: ['3.12', '3.14t']
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.platform.target }}
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --compatibility pypi
+          sccache: 'true'
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-windows-${{ matrix.platform.target }}-${{ matrix.python-version }}
+          path: dist
+
+  macos:
+    name: Build macOS (${{ matrix.platform.target }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.platform.runner }}
+    needs: [lint, rust-tests, python-tests]
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-14
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
+        python-version: ['3.12', '3.14t']
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --compatibility pypi
+          sccache: 'true'
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-macos-${{ matrix.platform.target }}-${{ matrix.python-version }}
+          path: dist
+
+# ===========================================================================
+# Phase 3 — Publish (depends on ALL previous jobs)
+# ===========================================================================
+  publish-crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
+    needs: [lint, rust-tests, python-tests, sdist, linux, windows, macos]
+    environment: pkg
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Publish to crates.io
+        run: ./scripts/ci-publish.py
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
+    needs: [lint, rust-tests, python-tests, sdist, linux, windows, macos]
+    environment: pkg
+    permissions:
+      id-token: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: dist
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Crate & Wheels
 
 on:
   push:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,4 +1,4 @@
-name: Wheels
+name: Release Crate & Wheels
 
 on:
   push:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,4 +1,4 @@
-name: Release Crate & Wheels
+name: Wheels
 
 on:
   workflow_dispatch:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,7 @@
 name: Release Crate & Wheels
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Create a new workflow for performing releases. This should:

- Maximally reuse existing workflows
- Avoid split releases due to crates.io updating completely independently of pypi

Leave the existing `wheels.yml` in place, but turn make it workflow_dispatch only. Once we're confident the new workflow is operating correctly, `wheels.yml` can be removed.