### PR TITLE
[Build] Fix Python tests

### DIFF
--- a/python/torch_tests/test_llamacpp.py
+++ b/python/torch_tests/test_llamacpp.py
@@ -1,7 +1,7 @@
 import llguidance.llamacpp
 import llama_cpp
 import os
-import requests # type: ignore
+import requests
 from typing import Any
 
 def get_llama_vocab_file(pytestconfig: Any) -> str:


### PR DESCRIPTION
Looks like a recent release of `requests` has rendered an `ignore` obsolete