### PR TITLE
Add C++ FFI tests

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -57,6 +57,12 @@ jobs:
     with:
       ref: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_id || github.sha }}
 
+  c-ffi-tests:
+    name: C FFI Tests
+    uses: ./.github/workflows/c-ffi-tests.yml
+    with:
+      ref: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_id || github.sha }}
+
   lark-tests:
     name: Lark Tests
     uses: ./.github/workflows/lark-tests.yml

--- a/.github/workflows/c-ffi-tests.yml
+++ b/.github/workflows/c-ffi-tests.yml
@@ -1,0 +1,45 @@
+name: C FFI Tests
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+        description: 'Git ref to checkout'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  c-ffi-tests:
+    name: C FFI Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.ref }}
+
+    - name: Install Boost
+      run: sudo apt-get update && sudo apt-get install -y libboost-test-dev
+
+    - name: Build llguidance (release)
+      run: cargo build --release
+      working-directory: parser
+
+    - name: Remove shared libs to force static linking
+      run: rm -f target/release/libllguidance.so target/release/libllguidance.dylib
+
+    - name: Configure CMake
+      run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+      working-directory: c_ffi_tests
+
+    - name: Build tests
+      run: cmake --build build
+      working-directory: c_ffi_tests
+
+    - name: Run tests
+      run: ctest --test-dir build --output-on-failure
+      working-directory: c_ffi_tests

--- a/.github/workflows/c-ffi-tests.yml
+++ b/.github/workflows/c-ffi-tests.yml
@@ -40,11 +40,7 @@ jobs:
       run: cmake --build build
       working-directory: c_ffi_tests
 
-    - name: Run tests
-      run: ctest --test-dir build --output-on-failure
-      working-directory: c_ffi_tests
-
-    - name: Generate JUnit XML
+    - name: Run tests & generate JUnit XML
       if: always()
       run: ./build/llg_ffi_tests --log_format=JUNIT --log_sink=junit.xml --log_level=all --report_level=no
       working-directory: c_ffi_tests

--- a/.github/workflows/c-ffi-tests.yml
+++ b/.github/workflows/c-ffi-tests.yml
@@ -43,3 +43,27 @@ jobs:
     - name: Run tests
       run: ctest --test-dir build --output-on-failure
       working-directory: c_ffi_tests
+
+    - name: Generate JUnit XML
+      if: always()
+      run: ./build/llg_ffi_tests --log_format=JUNIT --log_sink=junit.xml --log_level=all --report_level=no
+      working-directory: c_ffi_tests
+
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v6
+      if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
+      with:
+        report_paths: c_ffi_tests/junit.xml
+        fail_on_failure: true
+        require_passed_tests: true
+        include_passed: true
+        comment: true
+        check_name: C FFI Tests
+
+    - name: Publish Test Report (PR from fork)
+      uses: mikepenz/action-junit-report@v6
+      if: ${{ always() && github.event.pull_request.head.repo.full_name != github.repository }}
+      with:
+        report_paths: c_ffi_tests/junit.xml
+        annotate_only: true
+        fail_on_failure: true

--- a/c_ffi_tests/CMakeLists.txt
+++ b/c_ffi_tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TEST_SOURCES
     src/test_matcher.cpp
     src/test_stop_controller.cpp
     src/test_parallel.cpp
+    src/test_validate_grammar.cpp
     src/test_version.cpp
 )
 

--- a/c_ffi_tests/CMakeLists.txt
+++ b/c_ffi_tests/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.16)
+project(c_ffi_tests CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find Boost.Test
+find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+
+# Path to the llguidance static library and header
+set(LLG_ROOT "${CMAKE_SOURCE_DIR}/..")
+set(LLG_INCLUDE_DIR "${LLG_ROOT}/parser")
+set(LLG_LIB_DIR "${LLG_ROOT}/target/release")
+
+# Locate the static library
+find_library(LLG_LIBRARY
+    NAMES llguidance
+    PATHS "${LLG_LIB_DIR}"
+    NO_DEFAULT_PATH
+)
+if(NOT LLG_LIBRARY)
+    message(FATAL_ERROR "libllguidance not found in ${LLG_LIB_DIR}. Run 'cargo build --release' in the parser directory first.")
+endif()
+
+# Test data directory
+set(TEST_DATA_DIR "${LLG_ROOT}/sample_parser/data")
+add_compile_definitions(TEST_DATA_DIR="${TEST_DATA_DIR}")
+
+# Collect test sources
+set(TEST_SOURCES
+    src/test_helpers.cpp
+    src/test_tokenizer.cpp
+    src/test_tokenize.cpp
+    src/test_constraint.cpp
+    src/test_matcher.cpp
+    src/test_stop_controller.cpp
+    src/test_parallel.cpp
+    src/test_version.cpp
+)
+
+add_executable(llg_ffi_tests ${TEST_SOURCES})
+
+target_include_directories(llg_ffi_tests PRIVATE
+    ${LLG_INCLUDE_DIR}
+    ${Boost_INCLUDE_DIRS}
+    src
+)
+
+target_link_libraries(llg_ffi_tests PRIVATE
+    ${LLG_LIBRARY}
+    Boost::unit_test_framework
+    pthread
+    dl
+    m
+)
+
+# Enable CTest
+enable_testing()
+add_test(NAME llg_ffi_tests COMMAND llg_ffi_tests)

--- a/c_ffi_tests/src/test_constraint.cpp
+++ b/c_ffi_tests/src/test_constraint.cpp
@@ -35,7 +35,7 @@ ConstraintPtr make_constraint(LlgConstraint *constraint) {
 
 void require_no_error(const LlgConstraint *constraint) {
   const char *error = llg_get_error(constraint);
-  BOOST_REQUIRE_MESSAGE((error == nullptr), error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE((error == nullptr), (error ? error : "unexpected error"));
 }
 
 bool mask_allows(const LlgMaskResult &mask_res, uint32_t token) {
@@ -47,8 +47,8 @@ LlgMaskResult compute_mask_ok(LlgConstraint *constraint) {
   LlgMaskResult mask_res{};
   const int32_t rc = llg_compute_mask(constraint, &mask_res);
   const char *error = llg_get_error(constraint);
-  BOOST_REQUIRE_MESSAGE((rc == 0), error ? error : "llg_compute_mask failed");
-  BOOST_REQUIRE_MESSAGE((error == nullptr), error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE((rc == 0), (error ? error : "llg_compute_mask failed"));
+  BOOST_REQUIRE_MESSAGE((error == nullptr), (error ? error : "unexpected error"));
   return mask_res;
 }
 
@@ -56,8 +56,8 @@ LlgCommitResult commit_token_ok(LlgConstraint *constraint, uint32_t token) {
   LlgCommitResult commit_res{};
   const int32_t rc = llg_commit_token(constraint, token, &commit_res);
   const char *error = llg_get_error(constraint);
-  BOOST_REQUIRE_MESSAGE((rc == 0), error ? error : "llg_commit_token failed");
-  BOOST_REQUIRE_MESSAGE((error == nullptr), error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE((rc == 0), (error ? error : "llg_commit_token failed"));
+  BOOST_REQUIRE_MESSAGE((error == nullptr), (error ? error : "unexpected error"));
   return commit_res;
 }
 

--- a/c_ffi_tests/src/test_constraint.cpp
+++ b/c_ffi_tests/src/test_constraint.cpp
@@ -35,7 +35,7 @@ ConstraintPtr make_constraint(LlgConstraint *constraint) {
 
 void require_no_error(const LlgConstraint *constraint) {
   const char *error = llg_get_error(constraint);
-  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE((error == nullptr), error ? error : "unexpected error");
 }
 
 bool mask_allows(const LlgMaskResult &mask_res, uint32_t token) {
@@ -47,8 +47,8 @@ LlgMaskResult compute_mask_ok(LlgConstraint *constraint) {
   LlgMaskResult mask_res{};
   const int32_t rc = llg_compute_mask(constraint, &mask_res);
   const char *error = llg_get_error(constraint);
-  BOOST_REQUIRE_MESSAGE(rc == 0, error ? error : "llg_compute_mask failed");
-  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE((rc == 0), error ? error : "llg_compute_mask failed");
+  BOOST_REQUIRE_MESSAGE((error == nullptr), error ? error : "unexpected error");
   return mask_res;
 }
 
@@ -56,8 +56,8 @@ LlgCommitResult commit_token_ok(LlgConstraint *constraint, uint32_t token) {
   LlgCommitResult commit_res{};
   const int32_t rc = llg_commit_token(constraint, token, &commit_res);
   const char *error = llg_get_error(constraint);
-  BOOST_REQUIRE_MESSAGE(rc == 0, error ? error : "llg_commit_token failed");
-  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE((rc == 0), error ? error : "llg_commit_token failed");
+  BOOST_REQUIRE_MESSAGE((error == nullptr), error ? error : "unexpected error");
   return commit_res;
 }
 

--- a/c_ffi_tests/src/test_constraint.cpp
+++ b/c_ffi_tests/src/test_constraint.cpp
@@ -35,7 +35,7 @@ ConstraintPtr make_constraint(LlgConstraint *constraint) {
 
 void require_no_error(const LlgConstraint *constraint) {
   const char *error = llg_get_error(constraint);
-  BOOST_REQUIRE_MESSAGE(!error, error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
 }
 
 bool mask_allows(const LlgMaskResult &mask_res, uint32_t token) {
@@ -48,7 +48,7 @@ LlgMaskResult compute_mask_ok(LlgConstraint *constraint) {
   const int32_t rc = llg_compute_mask(constraint, &mask_res);
   const char *error = llg_get_error(constraint);
   BOOST_REQUIRE_MESSAGE(rc == 0, error ? error : "llg_compute_mask failed");
-  BOOST_REQUIRE_MESSAGE(!error, error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
   return mask_res;
 }
 
@@ -57,7 +57,7 @@ LlgCommitResult commit_token_ok(LlgConstraint *constraint, uint32_t token) {
   const int32_t rc = llg_commit_token(constraint, token, &commit_res);
   const char *error = llg_get_error(constraint);
   BOOST_REQUIRE_MESSAGE(rc == 0, error ? error : "llg_commit_token failed");
-  BOOST_REQUIRE_MESSAGE(!error, error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
   return commit_res;
 }
 

--- a/c_ffi_tests/src/test_constraint.cpp
+++ b/c_ffi_tests/src/test_constraint.cpp
@@ -284,4 +284,60 @@ BOOST_AUTO_TEST_CASE(free_constraint_with_error) {
   BOOST_REQUIRE(llg_get_error(constraint.get()) != nullptr);
 }
 
+BOOST_AUTO_TEST_CASE(compute_mask_on_error_constraint) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint = make_constraint(llg_new_constraint_json(&init, "{"));
+
+  BOOST_REQUIRE(llg_get_error(constraint.get()) != nullptr);
+
+  LlgMaskResult mask_res{};
+  BOOST_CHECK_EQUAL(llg_compute_mask(constraint.get(), &mask_res), -1);
+}
+
+BOOST_AUTO_TEST_CASE(commit_token_on_error_constraint) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint =
+      make_constraint(llg_new_constraint_lark(&init, R"(start: [)"));
+
+  BOOST_REQUIRE(llg_get_error(constraint.get()) != nullptr);
+
+  LlgCommitResult commit_res{};
+  BOOST_CHECK_EQUAL(llg_commit_token(constraint.get(), 'a', &commit_res), -1);
+}
+
+BOOST_AUTO_TEST_CASE(commit_disallowed_token) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint = make_constraint(llg_new_constraint_regex(&init, "a"));
+
+  require_no_error(constraint.get());
+
+  const auto mask_res = compute_mask_ok(constraint.get());
+  BOOST_REQUIRE(mask_res.sample_mask != nullptr);
+  BOOST_CHECK(mask_allows(mask_res, 'a'));
+  BOOST_CHECK(!mask_allows(mask_res, 'z'));
+
+  LlgCommitResult commit_res{};
+  BOOST_CHECK_EQUAL(llg_commit_token(constraint.get(), 'z', &commit_res), -1);
+}
+
+BOOST_AUTO_TEST_CASE(double_compute_mask) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint =
+      make_constraint(llg_new_constraint_regex(&init, "[a-z]+"));
+
+  require_no_error(constraint.get());
+
+  auto first_mask = compute_mask_ok(constraint.get());
+  BOOST_CHECK(first_mask.sample_mask != nullptr);
+
+  LlgMaskResult second_mask{};
+  BOOST_CHECK_EQUAL(llg_compute_mask(constraint.get(), &second_mask), 0);
+  BOOST_CHECK(llg_get_error(constraint.get()) == nullptr);
+  BOOST_CHECK(second_mask.sample_mask != nullptr);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_constraint.cpp
+++ b/c_ffi_tests/src/test_constraint.cpp
@@ -1,0 +1,287 @@
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "test_helpers.h"
+#include "llguidance.h"
+
+namespace {
+
+using TokenizerPtr = std::unique_ptr<LlgTokenizer, decltype(&llg_free_tokenizer)>;
+using ConstraintPtr =
+    std::unique_ptr<LlgConstraint, decltype(&llg_free_constraint)>;
+
+TokenizerPtr make_byte_tokenizer() {
+  return TokenizerPtr(create_byte_tokenizer(), &llg_free_tokenizer);
+}
+
+LlgConstraintInit make_constraint_init(const LlgTokenizer *tokenizer,
+                                       uint32_t log_buffer_level = 0,
+                                       uint32_t log_stderr_level = 0) {
+  LlgConstraintInit init{};
+  llg_constraint_init_set_defaults(&init, tokenizer);
+  init.log_buffer_level = log_buffer_level;
+  init.log_stderr_level = log_stderr_level;
+  return init;
+}
+
+ConstraintPtr make_constraint(LlgConstraint *constraint) {
+  BOOST_REQUIRE(constraint != nullptr);
+  return ConstraintPtr(constraint, &llg_free_constraint);
+}
+
+void require_no_error(const LlgConstraint *constraint) {
+  const char *error = llg_get_error(constraint);
+  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
+}
+
+bool mask_allows(const LlgMaskResult &mask_res, uint32_t token) {
+  return mask_res.sample_mask != nullptr &&
+         (mask_res.sample_mask[token / 32] & (uint32_t{1} << (token % 32))) != 0;
+}
+
+LlgMaskResult compute_mask_ok(LlgConstraint *constraint) {
+  LlgMaskResult mask_res{};
+  const int32_t rc = llg_compute_mask(constraint, &mask_res);
+  const char *error = llg_get_error(constraint);
+  BOOST_REQUIRE_MESSAGE(rc == 0, error ? error : "llg_compute_mask failed");
+  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
+  return mask_res;
+}
+
+LlgCommitResult commit_token_ok(LlgConstraint *constraint, uint32_t token) {
+  LlgCommitResult commit_res{};
+  const int32_t rc = llg_commit_token(constraint, token, &commit_res);
+  const char *error = llg_get_error(constraint);
+  BOOST_REQUIRE_MESSAGE(rc == 0, error ? error : "llg_commit_token failed");
+  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
+  return commit_res;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(constraint)
+
+BOOST_AUTO_TEST_CASE(init_set_defaults) {
+  auto tokenizer = make_byte_tokenizer();
+
+  LlgConstraintInit init{};
+  llg_constraint_init_set_defaults(&init, tokenizer.get());
+
+  BOOST_CHECK_EQUAL(init.ff_tokens_ok, false);
+  BOOST_CHECK_EQUAL(init.backtrack_ok, false);
+  BOOST_CHECK_EQUAL(init.log_stderr_level, 1U);
+  BOOST_CHECK_EQUAL(init.log_buffer_level, 0U);
+}
+
+BOOST_AUTO_TEST_CASE(new_constraint_regex_valid) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint =
+      make_constraint(llg_new_constraint_regex(&init, "[a-z]+"));
+
+  require_no_error(constraint.get());
+}
+
+BOOST_AUTO_TEST_CASE(new_constraint_regex_invalid) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint =
+      make_constraint(llg_new_constraint_regex(&init, "[z-a"));
+
+  BOOST_REQUIRE(llg_get_error(constraint.get()) != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(new_constraint_json_schema) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint = make_constraint(
+      llg_new_constraint_json(&init, R"({"type":"string"})"));
+
+  require_no_error(constraint.get());
+}
+
+BOOST_AUTO_TEST_CASE(new_constraint_lark) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint =
+      make_constraint(llg_new_constraint_lark(&init, R"(start: "hello")"));
+
+  require_no_error(constraint.get());
+}
+
+BOOST_AUTO_TEST_CASE(new_constraint_any_regex) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint =
+      make_constraint(llg_new_constraint_any(&init, "regex", "[0-9]+"));
+
+  require_no_error(constraint.get());
+}
+
+BOOST_AUTO_TEST_CASE(new_constraint_any_invalid_type) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint =
+      make_constraint(llg_new_constraint_any(&init, "not-a-type", "data"));
+
+  BOOST_REQUIRE(llg_get_error(constraint.get()) != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(compute_mask_and_commit_regex) {
+  constexpr uint32_t tok_a = 'a';
+  constexpr uint32_t tok_b = 'b';
+  constexpr uint32_t tok_c = 'c';
+
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint =
+      make_constraint(llg_new_constraint_regex(&init, "[a-c]+"));
+
+  require_no_error(constraint.get());
+
+  auto mask_res = compute_mask_ok(constraint.get());
+  BOOST_CHECK(!mask_res.is_stop);
+  BOOST_REQUIRE(mask_res.sample_mask != nullptr);
+  BOOST_CHECK(mask_allows(mask_res, tok_a));
+  BOOST_CHECK(mask_allows(mask_res, tok_b));
+  BOOST_CHECK(mask_allows(mask_res, tok_c));
+
+  auto commit_res = commit_token_ok(constraint.get(), tok_a);
+  BOOST_CHECK_EQUAL(commit_res.n_tokens, 1U);
+  BOOST_REQUIRE(commit_res.tokens != nullptr);
+  BOOST_CHECK_EQUAL(commit_res.tokens[0], tok_a);
+
+  mask_res = compute_mask_ok(constraint.get());
+  BOOST_CHECK(!mask_res.is_stop);
+  BOOST_REQUIRE(mask_res.sample_mask != nullptr);
+  BOOST_CHECK(mask_allows(mask_res, tok_a));
+  BOOST_CHECK(mask_allows(mask_res, tok_b));
+  BOOST_CHECK(mask_allows(mask_res, tok_c));
+  BOOST_CHECK(mask_allows(mask_res, BYTE_TOK_EOS));
+
+  commit_token_ok(constraint.get(), BYTE_TOK_EOS);
+
+  mask_res = compute_mask_ok(constraint.get());
+  BOOST_CHECK(mask_res.is_stop);
+}
+
+BOOST_AUTO_TEST_CASE(full_json_sampling_loop) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+
+  const auto schema_path =
+      std::string(TEST_DATA_DIR) + "/blog.schema.ll.json";
+  const auto sample_path = std::string(TEST_DATA_DIR) + "/blog.sample.json";
+  const auto schema = read_file(schema_path);
+  const auto sample = read_file(sample_path);
+
+  BOOST_REQUIRE(!schema.empty());
+  BOOST_REQUIRE(!sample.empty());
+
+  auto constraint =
+      make_constraint(llg_new_constraint(&init, schema.c_str()));
+
+  require_no_error(constraint.get());
+
+  const auto tokens = llg_tokenize(tokenizer.get(), sample);
+  BOOST_REQUIRE(!tokens.empty());
+
+  for (uint32_t token : tokens) {
+    auto mask_res = compute_mask_ok(constraint.get());
+    BOOST_CHECK(!mask_res.is_stop);
+    BOOST_REQUIRE(mask_res.sample_mask != nullptr);
+    BOOST_CHECK(mask_allows(mask_res, token));
+
+    auto commit_res = commit_token_ok(constraint.get(), token);
+    BOOST_CHECK_EQUAL(commit_res.n_tokens, 1U);
+    BOOST_REQUIRE(commit_res.tokens != nullptr);
+    BOOST_CHECK_EQUAL(commit_res.tokens[0], token);
+  }
+
+  auto mask_res = compute_mask_ok(constraint.get());
+  BOOST_CHECK(mask_res.is_stop);
+  BOOST_CHECK(llg_is_stopped(constraint.get()));
+}
+
+BOOST_AUTO_TEST_CASE(get_temperature) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint =
+      make_constraint(llg_new_constraint_regex(&init, "[a-z]+"));
+
+  require_no_error(constraint.get());
+
+  const auto mask_res = compute_mask_ok(constraint.get());
+  BOOST_CHECK_EQUAL(llg_get_temperature(constraint.get()), mask_res.temperature);
+}
+
+BOOST_AUTO_TEST_CASE(is_stopped_initially_false) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint =
+      make_constraint(llg_new_constraint_regex(&init, "[a-z]+"));
+
+  require_no_error(constraint.get());
+  BOOST_CHECK(!llg_is_stopped(constraint.get()));
+}
+
+BOOST_AUTO_TEST_CASE(flush_logs) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get(), 2, 0);
+  auto constraint =
+      make_constraint(llg_new_constraint_regex(&init, "[a-z]+"));
+
+  require_no_error(constraint.get());
+
+  compute_mask_ok(constraint.get());
+  commit_token_ok(constraint.get(), 'a');
+
+  const char *logs = llg_flush_logs(constraint.get());
+  BOOST_REQUIRE(logs != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(clone_constraint) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto original =
+      make_constraint(llg_new_constraint_regex(&init, "ab|bc"));
+
+  require_no_error(original.get());
+
+  auto initial_mask = compute_mask_ok(original.get());
+  BOOST_CHECK(mask_allows(initial_mask, 'a'));
+  BOOST_CHECK(mask_allows(initial_mask, 'b'));
+
+  auto clone = make_constraint(llg_clone_constraint(original.get()));
+  require_no_error(clone.get());
+
+  auto original_commit = commit_token_ok(original.get(), 'a');
+  BOOST_CHECK_EQUAL(original_commit.n_tokens, 1U);
+  BOOST_CHECK_EQUAL(original_commit.tokens[0], static_cast<uint32_t>('a'));
+
+  auto clone_commit = commit_token_ok(clone.get(), 'b');
+  BOOST_CHECK_EQUAL(clone_commit.n_tokens, 1U);
+  BOOST_CHECK_EQUAL(clone_commit.tokens[0], static_cast<uint32_t>('b'));
+
+  auto original_mask = compute_mask_ok(original.get());
+  BOOST_CHECK(mask_allows(original_mask, 'b'));
+  BOOST_CHECK(!mask_allows(original_mask, 'c'));
+
+  auto clone_mask = compute_mask_ok(clone.get());
+  BOOST_CHECK(!mask_allows(clone_mask, 'b'));
+  BOOST_CHECK(mask_allows(clone_mask, 'c'));
+}
+
+BOOST_AUTO_TEST_CASE(free_constraint_with_error) {
+  auto tokenizer = make_byte_tokenizer();
+  auto init = make_constraint_init(tokenizer.get());
+  auto constraint = make_constraint(llg_new_constraint(&init, "{"));
+
+  BOOST_REQUIRE(llg_get_error(constraint.get()) != nullptr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_constraint.cpp
+++ b/c_ffi_tests/src/test_constraint.cpp
@@ -35,7 +35,7 @@ ConstraintPtr make_constraint(LlgConstraint *constraint) {
 
 void require_no_error(const LlgConstraint *constraint) {
   const char *error = llg_get_error(constraint);
-  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE(!error, error ? error : "unexpected error");
 }
 
 bool mask_allows(const LlgMaskResult &mask_res, uint32_t token) {
@@ -48,7 +48,7 @@ LlgMaskResult compute_mask_ok(LlgConstraint *constraint) {
   const int32_t rc = llg_compute_mask(constraint, &mask_res);
   const char *error = llg_get_error(constraint);
   BOOST_REQUIRE_MESSAGE(rc == 0, error ? error : "llg_compute_mask failed");
-  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE(!error, error ? error : "unexpected error");
   return mask_res;
 }
 
@@ -57,7 +57,7 @@ LlgCommitResult commit_token_ok(LlgConstraint *constraint, uint32_t token) {
   const int32_t rc = llg_commit_token(constraint, token, &commit_res);
   const char *error = llg_get_error(constraint);
   BOOST_REQUIRE_MESSAGE(rc == 0, error ? error : "llg_commit_token failed");
-  BOOST_REQUIRE_MESSAGE(error == nullptr, error ? error : "unexpected error");
+  BOOST_REQUIRE_MESSAGE(!error, error ? error : "unexpected error");
   return commit_res;
 }
 

--- a/c_ffi_tests/src/test_helpers.cpp
+++ b/c_ffi_tests/src/test_helpers.cpp
@@ -49,7 +49,7 @@ LlgTokenizer *create_byte_tokenizer() {
 
   char error_buf[256];
   auto tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
-  BOOST_REQUIRE_MESSAGE(tok != nullptr,
+  BOOST_REQUIRE_MESSAGE(tok,
                         "Failed to create byte tokenizer: " << error_buf);
   return tok;
 }
@@ -94,7 +94,7 @@ LlgTokenizer *create_byte_tokenizer_v2() {
 
   char error_buf[256];
   auto tok = llg_new_tokenizer_v2(&tok_init, error_buf, sizeof(error_buf));
-  BOOST_REQUIRE_MESSAGE(tok != nullptr,
+  BOOST_REQUIRE_MESSAGE(tok,
                         "Failed to create byte tokenizer v2: " << error_buf);
   return tok;
 }

--- a/c_ffi_tests/src/test_helpers.cpp
+++ b/c_ffi_tests/src/test_helpers.cpp
@@ -49,7 +49,7 @@ LlgTokenizer *create_byte_tokenizer() {
 
   char error_buf[256];
   auto tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
-  BOOST_REQUIRE_MESSAGE(tok != nullptr,
+  BOOST_REQUIRE_MESSAGE((tok != nullptr),
                         "Failed to create byte tokenizer: " << error_buf);
   return tok;
 }
@@ -94,7 +94,7 @@ LlgTokenizer *create_byte_tokenizer_v2() {
 
   char error_buf[256];
   auto tok = llg_new_tokenizer_v2(&tok_init, error_buf, sizeof(error_buf));
-  BOOST_REQUIRE_MESSAGE(tok != nullptr,
+  BOOST_REQUIRE_MESSAGE((tok != nullptr),
                         "Failed to create byte tokenizer v2: " << error_buf);
   return tok;
 }

--- a/c_ffi_tests/src/test_helpers.cpp
+++ b/c_ffi_tests/src/test_helpers.cpp
@@ -49,7 +49,7 @@ LlgTokenizer *create_byte_tokenizer() {
 
   char error_buf[256];
   auto tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
-  BOOST_REQUIRE_MESSAGE(tok,
+  BOOST_REQUIRE_MESSAGE(tok != nullptr,
                         "Failed to create byte tokenizer: " << error_buf);
   return tok;
 }
@@ -94,7 +94,7 @@ LlgTokenizer *create_byte_tokenizer_v2() {
 
   char error_buf[256];
   auto tok = llg_new_tokenizer_v2(&tok_init, error_buf, sizeof(error_buf));
-  BOOST_REQUIRE_MESSAGE(tok,
+  BOOST_REQUIRE_MESSAGE(tok != nullptr,
                         "Failed to create byte tokenizer v2: " << error_buf);
   return tok;
 }

--- a/c_ffi_tests/src/test_helpers.cpp
+++ b/c_ffi_tests/src/test_helpers.cpp
@@ -1,0 +1,134 @@
+#define BOOST_TEST_MODULE LlgFfiTests
+#include <boost/test/unit_test.hpp>
+
+#include "test_helpers.h"
+
+extern "C" size_t byte_tokenize_callback(const void * /*user_data*/,
+                                         const uint8_t *bytes, size_t bytes_len,
+                                         uint32_t *output_tokens,
+                                         size_t output_tokens_len) {
+  if (output_tokens_len > 0) {
+    size_t n = std::min(output_tokens_len, bytes_len);
+    for (size_t i = 0; i < n; i++) {
+      output_tokens[i] = bytes[i];
+    }
+  }
+  return bytes_len;
+}
+
+LlgTokenizer *create_byte_tokenizer() {
+  std::vector<std::vector<uint8_t>> tokens;
+  tokens.reserve(BYTE_VOCAB_SIZE);
+  for (uint32_t i = 0; i < 256; i++) {
+    tokens.push_back({(uint8_t)i});
+  }
+  const char *eos = "<EOS>";
+  tokens.push_back(std::vector<uint8_t>(eos, eos + strlen(eos)));
+
+  std::vector<uint32_t> token_lens(tokens.size());
+  size_t total_size = 0;
+  for (size_t i = 0; i < tokens.size(); i++) {
+    token_lens[i] = (uint32_t)tokens[i].size();
+    total_size += token_lens[i];
+  }
+  std::vector<uint8_t> token_bytes(total_size);
+  size_t offset = 0;
+  for (size_t i = 0; i < tokens.size(); i++) {
+    std::copy(tokens[i].begin(), tokens[i].end(), token_bytes.data() + offset);
+    offset += token_lens[i];
+  }
+
+  LlgTokenizerInit tok_init = {};
+  tok_init.vocab_size = (uint32_t)tokens.size();
+  tok_init.tok_eos = BYTE_TOK_EOS;
+  tok_init.token_lens = token_lens.data();
+  tok_init.token_bytes = token_bytes.data();
+  tok_init.tokenize_assumes_string = false;
+  tok_init.tokenize_user_data = nullptr;
+  tok_init.tokenize_fn = byte_tokenize_callback;
+
+  char error_buf[256];
+  auto tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
+  BOOST_REQUIRE_MESSAGE(tok != nullptr,
+                        "Failed to create byte tokenizer: " << error_buf);
+  return tok;
+}
+
+LlgTokenizer *create_byte_tokenizer_v2() {
+  std::vector<std::vector<uint8_t>> tokens;
+  tokens.reserve(BYTE_V2_VOCAB_SIZE);
+  for (uint32_t i = 0; i < 256; i++) {
+    tokens.push_back({(uint8_t)i});
+  }
+  const char *eos = "<EOS>";
+  tokens.push_back(std::vector<uint8_t>(eos, eos + strlen(eos)));
+  const char *eos2 = "<EOS2>";
+  tokens.push_back(std::vector<uint8_t>(eos2, eos2 + strlen(eos2)));
+
+  std::vector<uint32_t> token_lens(tokens.size());
+  size_t total_size = 0;
+  for (size_t i = 0; i < tokens.size(); i++) {
+    token_lens[i] = (uint32_t)tokens[i].size();
+    total_size += token_lens[i];
+  }
+  std::vector<uint8_t> token_bytes(total_size);
+  size_t offset = 0;
+  for (size_t i = 0; i < tokens.size(); i++) {
+    std::copy(tokens[i].begin(), tokens[i].end(), token_bytes.data() + offset);
+    offset += token_lens[i];
+  }
+
+  uint32_t eos_extra[] = {BYTE_V2_TOK_EOS2};
+
+  LlgTokenizerInitV2 tok_init = {};
+  tok_init.struct_size = sizeof(tok_init);
+  tok_init.vocab_size = (uint32_t)tokens.size();
+  tok_init.tok_eos = BYTE_V2_TOK_EOS;
+  tok_init.token_lens = token_lens.data();
+  tok_init.token_bytes = token_bytes.data();
+  tok_init.tokenize_assumes_string = false;
+  tok_init.tokenize_user_data = nullptr;
+  tok_init.tokenize_fn = byte_tokenize_callback;
+  tok_init.tok_eos_extra = eos_extra;
+  tok_init.tok_eos_extra_count = 1;
+
+  char error_buf[256];
+  auto tok = llg_new_tokenizer_v2(&tok_init, error_buf, sizeof(error_buf));
+  BOOST_REQUIRE_MESSAGE(tok != nullptr,
+                        "Failed to create byte tokenizer v2: " << error_buf);
+  return tok;
+}
+
+std::string read_file(const std::string &path) {
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    return "";
+  }
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  return buffer.str();
+}
+
+std::vector<uint32_t> llg_tokenize(const LlgTokenizer *tok,
+                                   const std::string &s) {
+  size_t n = llg_tokenize_bytes(tok, (const uint8_t *)s.c_str(), s.size(),
+                                nullptr, 0);
+  std::vector<uint32_t> tokens(n);
+  llg_tokenize_bytes(tok, (const uint8_t *)s.c_str(), s.size(), tokens.data(),
+                     n);
+  return tokens;
+}
+
+std::string llg_stringify(const LlgTokenizer *tok,
+                          const std::vector<uint32_t> &tokens) {
+  char buffer[2048];
+  size_t n = llg_stringify_tokens(tok, tokens.data(), tokens.size(), buffer,
+                                  sizeof(buffer));
+  if (n >= sizeof(buffer)) {
+    std::vector<char> big_buf(n + 1);
+    llg_stringify_tokens(tok, tokens.data(), tokens.size(), big_buf.data(),
+                         big_buf.size());
+    return std::string(big_buf.data());
+  }
+  return std::string(buffer);
+}

--- a/c_ffi_tests/src/test_helpers.h
+++ b/c_ffi_tests/src/test_helpers.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "llguidance.h"
+
+// Byte-level tokenize callback: each byte is its own token.
+extern "C" size_t byte_tokenize_callback(const void *user_data,
+                                         const uint8_t *bytes, size_t bytes_len,
+                                         uint32_t *output_tokens,
+                                         size_t output_tokens_len);
+
+// Create a byte-level tokenizer using the v1 API.
+// Vocab: tokens 0..255 are single bytes, token 256 is <EOS>.
+LlgTokenizer *create_byte_tokenizer();
+
+// Create a byte-level tokenizer using the v2 API with two EOS tokens.
+// Vocab: tokens 0..255 are single bytes, token 256 is <EOS>, token 257 is <EOS2>.
+LlgTokenizer *create_byte_tokenizer_v2();
+
+// Read the contents of a file into a string.
+std::string read_file(const std::string &path);
+
+// Helper: tokenize a string using llg_tokenize_bytes.
+std::vector<uint32_t> llg_tokenize(const LlgTokenizer *tok, const std::string &s);
+
+// Helper: stringify tokens using llg_stringify_tokens.
+std::string llg_stringify(const LlgTokenizer *tok, const std::vector<uint32_t> &tokens);
+
+// Vocab size for the byte tokenizer (v1).
+constexpr uint32_t BYTE_VOCAB_SIZE = 257;
+// EOS token ID for the byte tokenizer (v1).
+constexpr uint32_t BYTE_TOK_EOS = 256;
+
+// Vocab size for the byte tokenizer (v2).
+constexpr uint32_t BYTE_V2_VOCAB_SIZE = 258;
+// Primary EOS token ID for the byte tokenizer (v2).
+constexpr uint32_t BYTE_V2_TOK_EOS = 256;
+// Extra EOS token ID for the byte tokenizer (v2).
+constexpr uint32_t BYTE_V2_TOK_EOS2 = 257;

--- a/c_ffi_tests/src/test_matcher.cpp
+++ b/c_ffi_tests/src/test_matcher.cpp
@@ -152,30 +152,40 @@ BOOST_AUTO_TEST_CASE(is_stopped_when_forced_eos) {
 
 BOOST_AUTO_TEST_CASE(rollback) {
   MatcherContext ctx;
-  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+  // "ab|ac" distinguishes states: after 'a', both 'b' and 'c' are valid.
+  // Consuming 'a','b' commits to the "ab" branch; rolling back 1 restores
+  // the post-'a' state where 'c' is also reachable.
+  auto matcher = ctx.make_matcher("regex", "ab|ac");
 
   check_matcher_has_no_error(matcher.get());
-  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 97), 0);
-  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 98), 0);
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 97), 0); // 'a'
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 98), 0); // 'b'
   BOOST_REQUIRE_EQUAL(llg_matcher_rollback(matcher.get(), 1), 0);
-  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 99), 0);
-  BOOST_CHECK(!llg_matcher_is_error(matcher.get()));
+
+  // After rollback we should be back in the post-'a' state
+  BOOST_REQUIRE_EQUAL(llg_matcher_compute_mask(matcher.get()), 0);
+  const uint32_t *mask = llg_matcher_get_mask(matcher.get());
+  BOOST_REQUIRE(mask != nullptr);
+  BOOST_CHECK(mask_has_token(mask, 99));  // 'c' should be allowed
+  BOOST_CHECK(mask_has_token(mask, 98));  // 'b' should be allowed
+  BOOST_CHECK(!mask_has_token(mask, 48)); // '0' should be rejected
 }
 
 BOOST_AUTO_TEST_CASE(reset) {
   MatcherContext ctx;
-  auto matcher = ctx.make_matcher("regex", "[a-z]+");
-  const uint32_t tokens[] = {97, 98, 99};
+  // "ab" requires exactly 'a' then 'b'. After consuming 'a', only 'b' is valid.
+  // After reset, only 'a' (the start) should be valid, not 'b'.
+  auto matcher = ctx.make_matcher("regex", "ab");
 
   check_matcher_has_no_error(matcher.get());
-  BOOST_REQUIRE_EQUAL(
-      llg_matcher_consume_tokens(matcher.get(), tokens, std::size(tokens)), 0);
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 97), 0); // 'a'
   BOOST_REQUIRE_EQUAL(llg_matcher_reset(matcher.get()), 0);
   BOOST_REQUIRE_EQUAL(llg_matcher_compute_mask(matcher.get()), 0);
 
   const uint32_t *mask = llg_matcher_get_mask(matcher.get());
   BOOST_REQUIRE(mask != nullptr);
-  BOOST_CHECK(mask_has_token(mask, 97));
+  BOOST_CHECK(mask_has_token(mask, 97));  // 'a' allowed (start position)
+  BOOST_CHECK(!mask_has_token(mask, 98)); // 'b' not allowed (would require 'a' first)
 }
 
 BOOST_AUTO_TEST_CASE(validate_tokens) {
@@ -210,6 +220,25 @@ BOOST_AUTO_TEST_CASE(compute_ff_tokens) {
       static_cast<int32_t>(output.size()));
   BOOST_CHECK_EQUAL_COLLECTIONS(output.begin(), output.end(), std::begin(expected),
                                 std::end(expected));
+}
+
+BOOST_AUTO_TEST_CASE(compute_ff_tokens_short_buffer) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "hello");
+  // Buffer of 3 + 1 canary element that must not be overwritten
+  constexpr uint32_t kCanary = 0xDEADBEEF;
+  std::vector<uint32_t> output(4, kCanary);
+  const uint32_t expected[] = {104, 101, 108};
+
+  check_matcher_has_no_error(matcher.get());
+  // Request only 3 slots; return value should still be 3 (the clamped length)
+  BOOST_REQUIRE_EQUAL(
+      llg_matcher_compute_ff_tokens(matcher.get(), output.data(), 3),
+      3);
+  BOOST_CHECK_EQUAL_COLLECTIONS(output.begin(), output.begin() + 3,
+                                std::begin(expected), std::end(expected));
+  // Canary must be untouched
+  BOOST_CHECK_EQUAL(output[3], kCanary);
 }
 
 BOOST_AUTO_TEST_CASE(clone_matcher) {

--- a/c_ffi_tests/src/test_matcher.cpp
+++ b/c_ffi_tests/src/test_matcher.cpp
@@ -241,6 +241,105 @@ BOOST_AUTO_TEST_CASE(compute_ff_tokens_short_buffer) {
   BOOST_CHECK_EQUAL(output[3], kCanary);
 }
 
+BOOST_AUTO_TEST_CASE(consume_invalid_token) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "ab");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_CHECK_EQUAL(llg_matcher_consume_token(matcher.get(), 120), -1); // 'x'
+  BOOST_CHECK(llg_matcher_is_error(matcher.get()));
+}
+
+BOOST_AUTO_TEST_CASE(rollback_zero) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 97), 0); // 'a'
+  BOOST_REQUIRE_EQUAL(llg_matcher_rollback(matcher.get(), 0), 0);
+  BOOST_REQUIRE_EQUAL(llg_matcher_compute_mask(matcher.get()), 0);
+
+  const uint32_t *mask = llg_matcher_get_mask(matcher.get());
+  BOOST_REQUIRE(mask != nullptr);
+  for (uint32_t token = 97; token <= 122; ++token) {
+    BOOST_CHECK(mask_has_token(mask, token));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(rollback_too_many) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 97), 0); // 'a'
+  BOOST_CHECK_EQUAL(llg_matcher_rollback(matcher.get(), 5), -1);
+}
+
+BOOST_AUTO_TEST_CASE(reset_error_state) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("lark", "start: (");
+
+  BOOST_REQUIRE(matcher != nullptr);
+  BOOST_REQUIRE(llg_matcher_is_error(matcher.get()));
+  BOOST_CHECK_EQUAL(llg_matcher_reset(matcher.get()), -1);
+}
+
+BOOST_AUTO_TEST_CASE(ff_tokens_zero_buffer) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "hello");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_CHECK_GE(llg_matcher_compute_ff_tokens(matcher.get(), nullptr, 0), 0);
+}
+
+BOOST_AUTO_TEST_CASE(compute_mask_into_wrong_size) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+
+  check_matcher_has_no_error(matcher.get());
+
+  const size_t mask_byte_size = llg_matcher_get_mask_byte_size(matcher.get());
+  std::vector<uint32_t> mask(mask_byte_size / sizeof(uint32_t));
+
+  BOOST_CHECK_EQUAL(
+      llg_matcher_compute_mask_into(matcher.get(), mask.data(), mask_byte_size / 2),
+      -1);
+}
+
+BOOST_AUTO_TEST_CASE(is_accepting_initial_plus) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_CHECK(!llg_matcher_is_accepting(matcher.get()));
+}
+
+BOOST_AUTO_TEST_CASE(is_accepting_initial_star) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]*");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_CHECK(llg_matcher_is_accepting(matcher.get()));
+}
+
+BOOST_AUTO_TEST_CASE(validate_tokens_empty) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_CHECK_EQUAL(llg_matcher_validate_tokens(matcher.get(), nullptr, 0), 0);
+}
+
+BOOST_AUTO_TEST_CASE(validate_tokens_all_invalid) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+  const uint32_t tokens[] = {48, 49};
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_CHECK_EQUAL(
+      llg_matcher_validate_tokens(matcher.get(), tokens, std::size(tokens)), 0);
+}
+
 BOOST_AUTO_TEST_CASE(clone_matcher) {
   MatcherContext ctx;
   auto matcher = ctx.make_matcher("regex", "[a-z]+");

--- a/c_ffi_tests/src/test_matcher.cpp
+++ b/c_ffi_tests/src/test_matcher.cpp
@@ -1,0 +1,249 @@
+#include <boost/test/unit_test.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+#include <memory>
+#include <vector>
+
+#include "llguidance.h"
+#include "test_helpers.h"
+
+namespace {
+
+struct TokenizerDeleter {
+  void operator()(LlgTokenizer *tok) const {
+    if (tok != nullptr) {
+      llg_free_tokenizer(tok);
+    }
+  }
+};
+
+struct MatcherDeleter {
+  void operator()(LlgMatcher *matcher) const {
+    if (matcher != nullptr) {
+      llg_free_matcher(matcher);
+    }
+  }
+};
+
+using TokenizerPtr = std::unique_ptr<LlgTokenizer, TokenizerDeleter>;
+using MatcherPtr = std::unique_ptr<LlgMatcher, MatcherDeleter>;
+
+struct MatcherContext {
+  TokenizerPtr tok;
+  LlgConstraintInit init;
+
+  MatcherContext() : tok(create_byte_tokenizer()) {
+    llg_constraint_init_set_defaults(&init, tok.get());
+    init.log_stderr_level = 0;
+  }
+
+  MatcherPtr make_matcher(const char *constraint_type, const char *data) const {
+    return MatcherPtr(llg_new_matcher(&init, constraint_type, data));
+  }
+};
+
+bool mask_has_token(const uint32_t *mask, uint32_t token) {
+  return mask != nullptr &&
+         (mask[token / 32] & (uint32_t{1} << (token % 32))) != 0;
+}
+
+void check_matcher_has_no_error(LlgMatcher *matcher) {
+  BOOST_REQUIRE(matcher != nullptr);
+  BOOST_CHECK(!llg_matcher_is_error(matcher));
+  BOOST_CHECK(llg_matcher_get_error(matcher) == nullptr);
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(matcher)
+
+BOOST_AUTO_TEST_CASE(new_matcher_regex) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+
+  check_matcher_has_no_error(matcher.get());
+}
+
+BOOST_AUTO_TEST_CASE(new_matcher_json_schema) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("json_schema", R"({"type":"number"})");
+
+  check_matcher_has_no_error(matcher.get());
+}
+
+BOOST_AUTO_TEST_CASE(new_matcher_invalid_grammar) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("lark", "start: (");
+
+  BOOST_REQUIRE(matcher != nullptr);
+  BOOST_CHECK(llg_matcher_is_error(matcher.get()));
+  BOOST_CHECK(llg_matcher_get_error(matcher.get()) != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(compute_mask_basic) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[abc]+");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_REQUIRE_EQUAL(llg_matcher_compute_mask(matcher.get()), 0);
+
+  const uint32_t *mask = llg_matcher_get_mask(matcher.get());
+  BOOST_REQUIRE(mask != nullptr);
+  BOOST_CHECK(mask_has_token(mask, 97));
+  BOOST_CHECK(mask_has_token(mask, 98));
+  BOOST_CHECK(mask_has_token(mask, 99));
+}
+
+BOOST_AUTO_TEST_CASE(compute_mask_into) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[abc]+");
+
+  check_matcher_has_no_error(matcher.get());
+
+  const size_t mask_byte_size = llg_matcher_get_mask_byte_size(matcher.get());
+  std::vector<uint32_t> mask(mask_byte_size / sizeof(uint32_t));
+
+  BOOST_REQUIRE_EQUAL(
+      llg_matcher_compute_mask_into(matcher.get(), mask.data(), mask_byte_size),
+      0);
+  BOOST_CHECK(mask_has_token(mask.data(), 97));
+  BOOST_CHECK(mask_has_token(mask.data(), 98));
+  BOOST_CHECK(mask_has_token(mask.data(), 99));
+}
+
+BOOST_AUTO_TEST_CASE(consume_token_single) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_CHECK_EQUAL(llg_matcher_consume_token(matcher.get(), 97), 0);
+}
+
+BOOST_AUTO_TEST_CASE(consume_tokens_multiple) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+  const uint32_t tokens[] = {104, 101, 108, 108, 111};
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_CHECK_EQUAL(
+      llg_matcher_consume_tokens(matcher.get(), tokens, std::size(tokens)), 0);
+}
+
+BOOST_AUTO_TEST_CASE(is_accepting_after_valid_input) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 97), 0);
+  BOOST_CHECK(llg_matcher_is_accepting(matcher.get()));
+}
+
+BOOST_AUTO_TEST_CASE(is_stopped_when_forced_eos) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "a");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 97), 0);
+  BOOST_CHECK(llg_matcher_is_stopped(matcher.get()));
+}
+
+BOOST_AUTO_TEST_CASE(rollback) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 97), 0);
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 98), 0);
+  BOOST_REQUIRE_EQUAL(llg_matcher_rollback(matcher.get(), 1), 0);
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 99), 0);
+  BOOST_CHECK(!llg_matcher_is_error(matcher.get()));
+}
+
+BOOST_AUTO_TEST_CASE(reset) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+  const uint32_t tokens[] = {97, 98, 99};
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_REQUIRE_EQUAL(
+      llg_matcher_consume_tokens(matcher.get(), tokens, std::size(tokens)), 0);
+  BOOST_REQUIRE_EQUAL(llg_matcher_reset(matcher.get()), 0);
+  BOOST_REQUIRE_EQUAL(llg_matcher_compute_mask(matcher.get()), 0);
+
+  const uint32_t *mask = llg_matcher_get_mask(matcher.get());
+  BOOST_REQUIRE(mask != nullptr);
+  BOOST_CHECK(mask_has_token(mask, 97));
+}
+
+BOOST_AUTO_TEST_CASE(validate_tokens) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+  const uint32_t tokens[] = {97, 98, 99};
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_CHECK_EQUAL(
+      llg_matcher_validate_tokens(matcher.get(), tokens, std::size(tokens)), 3);
+}
+
+BOOST_AUTO_TEST_CASE(validate_tokens_partial) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+  const uint32_t tokens[] = {97, 48};
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_CHECK_EQUAL(
+      llg_matcher_validate_tokens(matcher.get(), tokens, std::size(tokens)), 1);
+}
+
+BOOST_AUTO_TEST_CASE(compute_ff_tokens) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "hello");
+  std::vector<uint32_t> output(5);
+  const uint32_t expected[] = {104, 101, 108, 108, 111};
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_REQUIRE_EQUAL(
+      llg_matcher_compute_ff_tokens(matcher.get(), output.data(), output.size()),
+      static_cast<int32_t>(output.size()));
+  BOOST_CHECK_EQUAL_COLLECTIONS(output.begin(), output.end(), std::begin(expected),
+                                std::end(expected));
+}
+
+BOOST_AUTO_TEST_CASE(clone_matcher) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "[a-z]+");
+
+  check_matcher_has_no_error(matcher.get());
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 97), 0);
+  BOOST_REQUIRE_EQUAL(llg_matcher_consume_token(matcher.get(), 98), 0);
+
+  MatcherPtr clone(llg_clone_matcher(matcher.get()));
+  BOOST_REQUIRE(clone != nullptr);
+  BOOST_CHECK(llg_matcher_is_accepting(matcher.get()));
+  BOOST_CHECK(llg_matcher_is_accepting(clone.get()));
+
+  BOOST_REQUIRE_EQUAL(llg_matcher_compute_mask(matcher.get()), 0);
+  BOOST_REQUIRE_EQUAL(llg_matcher_compute_mask(clone.get()), 0);
+
+  const uint32_t *matcher_mask = llg_matcher_get_mask(matcher.get());
+  const uint32_t *clone_mask = llg_matcher_get_mask(clone.get());
+  const size_t mask_byte_size = llg_matcher_get_mask_byte_size(matcher.get());
+
+  BOOST_REQUIRE(matcher_mask != nullptr);
+  BOOST_REQUIRE(clone_mask != nullptr);
+  BOOST_CHECK_EQUAL(std::memcmp(matcher_mask, clone_mask, mask_byte_size), 0);
+}
+
+BOOST_AUTO_TEST_CASE(free_matcher_no_crash) {
+  MatcherContext ctx;
+  LlgMatcher *matcher = llg_new_matcher(&ctx.init, "regex", "[a-z]+");
+
+  BOOST_REQUIRE(matcher != nullptr);
+  llg_free_matcher(matcher);
+  BOOST_TEST(true);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_matcher.cpp
+++ b/c_ffi_tests/src/test_matcher.cpp
@@ -284,12 +284,25 @@ BOOST_AUTO_TEST_CASE(reset_error_state) {
   BOOST_CHECK_EQUAL(llg_matcher_reset(matcher.get()), -1);
 }
 
-BOOST_AUTO_TEST_CASE(ff_tokens_zero_buffer) {
+BOOST_AUTO_TEST_CASE(ff_tokens_null_output_returns_error) {
   MatcherContext ctx;
   auto matcher = ctx.make_matcher("regex", "hello");
 
   check_matcher_has_no_error(matcher.get());
-  BOOST_CHECK_GE(llg_matcher_compute_ff_tokens(matcher.get(), nullptr, 0), 0);
+  // Passing nullptr is explicitly rejected even with output_len=0
+  BOOST_CHECK_EQUAL(llg_matcher_compute_ff_tokens(matcher.get(), nullptr, 0), -1);
+}
+
+BOOST_AUTO_TEST_CASE(ff_tokens_zero_length_buffer) {
+  MatcherContext ctx;
+  auto matcher = ctx.make_matcher("regex", "hello");
+
+  check_matcher_has_no_error(matcher.get());
+  uint32_t dummy = 0xDEADBEEF;
+  // Zero-length buffer: returns 0 tokens written, does not touch buffer
+  int32_t n = llg_matcher_compute_ff_tokens(matcher.get(), &dummy, 0);
+  BOOST_CHECK_EQUAL(n, 0);
+  BOOST_CHECK_EQUAL(dummy, 0xDEADBEEF);
 }
 
 BOOST_AUTO_TEST_CASE(compute_mask_into_wrong_size) {

--- a/c_ffi_tests/src/test_parallel.cpp
+++ b/c_ffi_tests/src/test_parallel.cpp
@@ -1,0 +1,133 @@
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "test_helpers.h"
+#include "llguidance.h"
+
+namespace {
+
+constexpr size_t kMaskU32Count = (BYTE_VOCAB_SIZE + 31) / 32;
+constexpr size_t kMaskByteLen = kMaskU32Count * sizeof(uint32_t);
+
+struct ConstraintDeleter {
+  void operator()(LlgConstraint *ptr) const {
+    if (ptr != nullptr) {
+      llg_free_constraint(ptr);
+    }
+  }
+};
+
+struct TokenizerDeleter {
+  void operator()(LlgTokenizer *ptr) const {
+    if (ptr != nullptr) {
+      llg_free_tokenizer(ptr);
+    }
+  }
+};
+
+using ConstraintPtr = std::unique_ptr<LlgConstraint, ConstraintDeleter>;
+using TokenizerPtr = std::unique_ptr<LlgTokenizer, TokenizerDeleter>;
+
+bool mask_allows(const std::vector<uint32_t> &mask, uint32_t token) {
+  return (mask[token / 32] & (uint32_t{1} << (token % 32))) != 0;
+}
+
+ConstraintPtr new_regex_constraint(const LlgTokenizer *tokenizer,
+                                   const char *regex) {
+  LlgConstraintInit init = {};
+  llg_constraint_init_set_defaults(&init, tokenizer);
+  init.log_stderr_level = 0;
+
+  ConstraintPtr constraint(llg_new_constraint_regex(&init, regex));
+  BOOST_REQUIRE(constraint.get() != nullptr);
+  BOOST_REQUIRE_MESSAGE(llg_get_error(constraint.get()) == nullptr,
+                        llg_get_error(constraint.get()));
+  return constraint;
+}
+
+extern "C" void mark_done_callback(const void *user_data) {
+  auto *done = static_cast<std::atomic<bool> *>(
+      const_cast<void *>(user_data));
+  done->store(true, std::memory_order_release);
+}
+
+void wait_for_done(const std::atomic<bool> &done) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (!done.load(std::memory_order_acquire) &&
+         std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  BOOST_REQUIRE(done.load(std::memory_order_acquire));
+}
+
+std::vector<uint32_t> compute_mask_sequential(LlgConstraint *constraint) {
+  LlgMaskResult result = {};
+  BOOST_REQUIRE_EQUAL(llg_compute_mask(constraint, &result), 0);
+  BOOST_REQUIRE(result.sample_mask != nullptr);
+  return std::vector<uint32_t>(result.sample_mask,
+                               result.sample_mask + kMaskU32Count);
+}
+
+std::vector<uint32_t> compute_mask_parallel(LlgConstraint *constraint) {
+  std::vector<uint32_t> mask(kMaskU32Count, 0);
+  LlgConstraintStep step = {constraint, mask.data(), kMaskByteLen};
+  std::atomic<bool> done{false};
+
+  llg_par_compute_mask(&step, 1, &done, mark_done_callback);
+  wait_for_done(done);
+
+  return mask;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(parallel)
+
+BOOST_AUTO_TEST_CASE(par_compute_mask_basic) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  auto alpha_constraint = new_regex_constraint(tokenizer.get(), "[a-z]+");
+  auto digit_constraint = new_regex_constraint(tokenizer.get(), "[0-9]+");
+
+  std::vector<uint32_t> alpha_mask(kMaskU32Count, 0);
+  std::vector<uint32_t> digit_mask(kMaskU32Count, 0);
+  std::atomic<bool> done{false};
+  std::array<LlgConstraintStep, 2> steps = {{
+      {alpha_constraint.get(), alpha_mask.data(), kMaskByteLen},
+      {digit_constraint.get(), digit_mask.data(), kMaskByteLen},
+  }};
+
+  llg_par_compute_mask(steps.data(), steps.size(), &done, mark_done_callback);
+  wait_for_done(done);
+
+  BOOST_TEST(mask_allows(alpha_mask, static_cast<uint32_t>('a')));
+  BOOST_TEST(mask_allows(alpha_mask, static_cast<uint32_t>('z')));
+  BOOST_TEST(!mask_allows(alpha_mask, static_cast<uint32_t>('0')));
+
+  BOOST_TEST(mask_allows(digit_mask, static_cast<uint32_t>('0')));
+  BOOST_TEST(mask_allows(digit_mask, static_cast<uint32_t>('9')));
+  BOOST_TEST(!mask_allows(digit_mask, static_cast<uint32_t>('a')));
+}
+
+BOOST_AUTO_TEST_CASE(par_compute_mask_matches_sequential) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  auto constraint_seq = new_regex_constraint(tokenizer.get(), "[a-z]+");
+  auto constraint_par = new_regex_constraint(tokenizer.get(), "[a-z]+");
+
+  const auto sequential_mask = compute_mask_sequential(constraint_seq.get());
+  const auto parallel_mask = compute_mask_parallel(constraint_par.get());
+
+  BOOST_REQUIRE_EQUAL(parallel_mask.size(), sequential_mask.size());
+  for (size_t i = 0; i < parallel_mask.size(); ++i) {
+    BOOST_TEST(parallel_mask[i] == sequential_mask[i]);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_parallel.cpp
+++ b/c_ffi_tests/src/test_parallel.cpp
@@ -47,7 +47,7 @@ ConstraintPtr new_regex_constraint(const LlgTokenizer *tokenizer,
 
   ConstraintPtr constraint(llg_new_constraint_regex(&init, regex));
   BOOST_REQUIRE(constraint.get() != nullptr);
-  BOOST_REQUIRE_MESSAGE(llg_get_error(constraint.get()) == nullptr,
+  BOOST_REQUIRE_MESSAGE((llg_get_error(constraint.get()) == nullptr),
                         llg_get_error(constraint.get()));
   return constraint;
 }

--- a/c_ffi_tests/src/test_parallel.cpp
+++ b/c_ffi_tests/src/test_parallel.cpp
@@ -47,7 +47,7 @@ ConstraintPtr new_regex_constraint(const LlgTokenizer *tokenizer,
 
   ConstraintPtr constraint(llg_new_constraint_regex(&init, regex));
   BOOST_REQUIRE(constraint.get() != nullptr);
-  BOOST_REQUIRE_MESSAGE(llg_get_error(constraint.get()) == nullptr,
+  BOOST_REQUIRE_MESSAGE(!llg_get_error(constraint.get()),
                         llg_get_error(constraint.get()));
   return constraint;
 }

--- a/c_ffi_tests/src/test_parallel.cpp
+++ b/c_ffi_tests/src/test_parallel.cpp
@@ -47,7 +47,7 @@ ConstraintPtr new_regex_constraint(const LlgTokenizer *tokenizer,
 
   ConstraintPtr constraint(llg_new_constraint_regex(&init, regex));
   BOOST_REQUIRE(constraint.get() != nullptr);
-  BOOST_REQUIRE_MESSAGE(!llg_get_error(constraint.get()),
+  BOOST_REQUIRE_MESSAGE(llg_get_error(constraint.get()) == nullptr,
                         llg_get_error(constraint.get()));
   return constraint;
 }

--- a/c_ffi_tests/src/test_parallel.cpp
+++ b/c_ffi_tests/src/test_parallel.cpp
@@ -59,13 +59,17 @@ extern "C" void mark_done_callback(const void *user_data) {
 }
 
 void wait_for_done(const std::atomic<bool> &done) {
+  // Use a generous deadline so the Rayon callback has time to complete.
+  // We must not unwind (via BOOST_REQUIRE) while the callback may still
+  // access stack-owned data through the pointer descriptors.
   const auto deadline =
-      std::chrono::steady_clock::now() + std::chrono::seconds(2);
+      std::chrono::steady_clock::now() + std::chrono::seconds(30);
   while (!done.load(std::memory_order_acquire) &&
          std::chrono::steady_clock::now() < deadline) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  BOOST_REQUIRE(done.load(std::memory_order_acquire));
+  BOOST_REQUIRE_MESSAGE(done.load(std::memory_order_acquire),
+                        "Timed out waiting for parallel compute_mask callback");
 }
 
 std::vector<uint32_t> compute_mask_sequential(LlgConstraint *constraint) {

--- a/c_ffi_tests/src/test_parallel.cpp
+++ b/c_ffi_tests/src/test_parallel.cpp
@@ -134,4 +134,30 @@ BOOST_AUTO_TEST_CASE(par_compute_mask_matches_sequential) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(par_compute_mask_single_step) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  auto constraint = new_regex_constraint(tokenizer.get(), "[a-z]+");
+
+  std::vector<uint32_t> mask(kMaskU32Count, 0);
+  std::atomic<bool> done{false};
+  LlgConstraintStep step = {constraint.get(), mask.data(), kMaskByteLen};
+
+  llg_par_compute_mask(&step, 1, &done, mark_done_callback);
+  wait_for_done(done);
+
+  BOOST_TEST(mask_allows(mask, static_cast<uint32_t>('a')));
+  BOOST_TEST(mask_allows(mask, static_cast<uint32_t>('z')));
+  BOOST_TEST(!mask_allows(mask, static_cast<uint32_t>('0')));
+}
+
+BOOST_AUTO_TEST_CASE(par_compute_mask_zero_steps) {
+  std::array<LlgConstraintStep, 1> steps = {{
+      {nullptr, nullptr, 0},
+  }};
+  std::atomic<bool> done{false};
+
+  llg_par_compute_mask(steps.data(), 0, &done, mark_done_callback);
+  wait_for_done(done);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_stop_controller.cpp
+++ b/c_ffi_tests/src/test_stop_controller.cpp
@@ -1,0 +1,165 @@
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "test_helpers.h"
+#include "llguidance.h"
+
+namespace {
+
+struct StopControllerDeleter {
+  void operator()(LlgStopController *ptr) const {
+    if (ptr != nullptr) {
+      llg_free_stop_controller(ptr);
+    }
+  }
+};
+
+struct TokenizerDeleter {
+  void operator()(LlgTokenizer *ptr) const {
+    if (ptr != nullptr) {
+      llg_free_tokenizer(ptr);
+    }
+  }
+};
+
+using StopControllerPtr =
+    std::unique_ptr<LlgStopController, StopControllerDeleter>;
+using TokenizerPtr = std::unique_ptr<LlgTokenizer, TokenizerDeleter>;
+
+std::string committed_text(LlgStopController *stop_ctrl, uint32_t token,
+                           size_t &output_len, bool &is_stopped) {
+  const char *output =
+      llg_stop_commit_token(stop_ctrl, token, &output_len, &is_stopped);
+  BOOST_REQUIRE(output != nullptr);
+  return std::string(output, output_len);
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(stop_controller)
+
+BOOST_AUTO_TEST_CASE(create_with_stop_token) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  const uint32_t stop_tokens[] = {BYTE_TOK_EOS};
+  char error[256] = {};
+
+  StopControllerPtr stop_ctrl(llg_new_stop_controller(
+      tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
+
+  BOOST_TEST(stop_ctrl.get() != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(create_with_stop_regex) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  char error[256] = {};
+
+  StopControllerPtr stop_ctrl(llg_new_stop_controller(
+      tokenizer.get(), nullptr, 0, "\\nEND", error, sizeof(error)));
+
+  BOOST_TEST(stop_ctrl.get() != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(create_invalid_regex) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  char error[256] = {};
+
+  StopControllerPtr stop_ctrl(llg_new_stop_controller(
+      tokenizer.get(), nullptr, 0, "[z-a", error, sizeof(error)));
+
+  BOOST_TEST(stop_ctrl.get() == nullptr);
+  BOOST_TEST(error[0] != '\0');
+}
+
+BOOST_AUTO_TEST_CASE(commit_token_no_stop) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  const uint32_t stop_tokens[] = {BYTE_TOK_EOS};
+  char error[256] = {};
+  StopControllerPtr stop_ctrl(llg_new_stop_controller(
+      tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
+  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
+
+  const std::array<uint32_t, 5> tokens = {104, 101, 108, 108, 111};
+  const std::array<std::string, 5> expected = {"h", "e", "l", "l", "o"};
+
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    size_t output_len = 0;
+    bool is_stopped = true;
+    const auto output =
+        committed_text(stop_ctrl.get(), tokens[i], output_len, is_stopped);
+
+    BOOST_TEST(is_stopped == false);
+    BOOST_TEST(output_len == expected[i].size());
+    BOOST_TEST(output == expected[i]);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(commit_token_stop_detected) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  const uint32_t stop_tokens[] = {BYTE_TOK_EOS};
+  char error[256] = {};
+  StopControllerPtr stop_ctrl(llg_new_stop_controller(
+      tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
+  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
+
+  for (uint32_t token : {104u, 101u, 108u}) {
+    size_t output_len = 0;
+    bool is_stopped = true;
+    const auto output =
+        committed_text(stop_ctrl.get(), token, output_len, is_stopped);
+
+    BOOST_TEST(is_stopped == false);
+    BOOST_TEST(output_len == 1u);
+    BOOST_TEST(output.empty() == false);
+  }
+
+  size_t output_len = 99;
+  bool is_stopped = false;
+  const auto output =
+      committed_text(stop_ctrl.get(), BYTE_TOK_EOS, output_len, is_stopped);
+
+  BOOST_TEST(is_stopped == true);
+  BOOST_TEST(output_len == 0u);
+  BOOST_TEST(output.empty());
+}
+
+BOOST_AUTO_TEST_CASE(clone_stop_controller) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  const uint32_t stop_tokens[] = {BYTE_TOK_EOS};
+  char error[256] = {};
+  StopControllerPtr stop_ctrl(llg_new_stop_controller(
+      tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
+  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
+
+  size_t output_len = 0;
+  bool is_stopped = true;
+  BOOST_TEST(committed_text(stop_ctrl.get(), 104, output_len, is_stopped) ==
+             "h");
+  BOOST_TEST(is_stopped == false);
+  BOOST_TEST(committed_text(stop_ctrl.get(), 101, output_len, is_stopped) ==
+             "e");
+  BOOST_TEST(is_stopped == false);
+
+  StopControllerPtr clone(llg_clone_stop_controller(stop_ctrl.get()));
+  BOOST_REQUIRE(clone.get() != nullptr);
+
+  BOOST_TEST(committed_text(stop_ctrl.get(), 108, output_len, is_stopped) ==
+             "l");
+  BOOST_TEST(is_stopped == false);
+
+  BOOST_TEST(committed_text(clone.get(), 108, output_len, is_stopped) == "l");
+  BOOST_TEST(is_stopped == false);
+  BOOST_TEST(committed_text(clone.get(), BYTE_TOK_EOS, output_len, is_stopped)
+                 .empty());
+  BOOST_TEST(output_len == 0u);
+  BOOST_TEST(is_stopped == true);
+
+  BOOST_TEST(committed_text(stop_ctrl.get(), 111, output_len, is_stopped) ==
+             "o");
+  BOOST_TEST(is_stopped == false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_stop_controller.cpp
+++ b/c_ffi_tests/src/test_stop_controller.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(commit_token_no_stop) {
   char error[256] = {};
   StopControllerPtr stop_ctrl(llg_new_stop_controller(
       tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
-  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
+  BOOST_REQUIRE_MESSAGE(stop_ctrl.get(), error);
 
   const std::array<uint32_t, 5> tokens = {104, 101, 108, 108, 111};
   const std::array<std::string, 5> expected = {"h", "e", "l", "l", "o"};
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(commit_token_stop_detected) {
   char error[256] = {};
   StopControllerPtr stop_ctrl(llg_new_stop_controller(
       tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
-  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
+  BOOST_REQUIRE_MESSAGE(stop_ctrl.get(), error);
 
   for (uint32_t token : {104u, 101u, 108u}) {
     size_t output_len = 0;
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(clone_stop_controller) {
   char error[256] = {};
   StopControllerPtr stop_ctrl(llg_new_stop_controller(
       tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
-  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
+  BOOST_REQUIRE_MESSAGE(stop_ctrl.get(), error);
 
   size_t output_len = 0;
   bool is_stopped = true;

--- a/c_ffi_tests/src/test_stop_controller.cpp
+++ b/c_ffi_tests/src/test_stop_controller.cpp
@@ -158,4 +158,61 @@ BOOST_AUTO_TEST_CASE(clone_stop_controller) {
   BOOST_TEST(is_stopped == true);
 }
 
+BOOST_AUTO_TEST_CASE(create_with_multiple_stop_tokens) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  const uint32_t stop_tokens[] = {BYTE_TOK_EOS, 200};
+  char error[256] = {};
+
+  StopControllerPtr stop_ctrl(llg_new_stop_controller(
+      tokenizer.get(), stop_tokens, 2, nullptr, error, sizeof(error)));
+  BOOST_REQUIRE_MESSAGE((stop_ctrl.get() != nullptr), error);
+
+  size_t output_len = 0;
+  bool is_stopped = false;
+  const auto output =
+      committed_text(stop_ctrl.get(), 200, output_len, is_stopped);
+
+  BOOST_TEST(is_stopped == true);
+  BOOST_TEST(output_len == 0u);
+  BOOST_TEST(output.empty());
+}
+
+BOOST_AUTO_TEST_CASE(commit_after_stop) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  const uint32_t stop_tokens[] = {BYTE_TOK_EOS};
+  char error[256] = {};
+  StopControllerPtr stop_ctrl(llg_new_stop_controller(
+      tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
+  BOOST_REQUIRE_MESSAGE((stop_ctrl.get() != nullptr), error);
+
+  size_t output_len = 0;
+  bool is_stopped = false;
+  committed_text(stop_ctrl.get(), BYTE_TOK_EOS, output_len, is_stopped);
+  BOOST_TEST(is_stopped == true);
+
+  const char *output =
+      llg_stop_commit_token(stop_ctrl.get(), static_cast<uint32_t>('a'),
+                            &output_len, &is_stopped);
+  BOOST_REQUIRE(output != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(create_with_both_token_and_regex) {
+  TokenizerPtr tokenizer(create_byte_tokenizer());
+  const uint32_t stop_tokens[] = {BYTE_TOK_EOS};
+  char error[256] = {};
+
+  StopControllerPtr stop_ctrl(llg_new_stop_controller(
+      tokenizer.get(), stop_tokens, 1, "xy", error, sizeof(error)));
+  BOOST_REQUIRE_MESSAGE((stop_ctrl.get() != nullptr), error);
+
+  size_t output_len = 0;
+  bool is_stopped = false;
+  const auto output =
+      committed_text(stop_ctrl.get(), BYTE_TOK_EOS, output_len, is_stopped);
+
+  BOOST_TEST(is_stopped == true);
+  BOOST_TEST(output_len == 0u);
+  BOOST_TEST(output.empty());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_stop_controller.cpp
+++ b/c_ffi_tests/src/test_stop_controller.cpp
@@ -128,38 +128,34 @@ BOOST_AUTO_TEST_CASE(commit_token_stop_detected) {
 
 BOOST_AUTO_TEST_CASE(clone_stop_controller) {
   TokenizerPtr tokenizer(create_byte_tokenizer());
-  const uint32_t stop_tokens[] = {BYTE_TOK_EOS};
   char error[256] = {};
+  // Use regex stop pattern "ab" so the controller accumulates match state.
   StopControllerPtr stop_ctrl(llg_new_stop_controller(
-      tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
+      tokenizer.get(), nullptr, 0, "ab", error, sizeof(error)));
   BOOST_REQUIRE_MESSAGE((stop_ctrl.get() != nullptr), error);
 
+  // Commit 'x' (120) - no match progress, text is emitted
   size_t output_len = 0;
-  bool is_stopped = true;
-  BOOST_TEST(committed_text(stop_ctrl.get(), 104, output_len, is_stopped) ==
-             "h");
-  BOOST_TEST(is_stopped == false);
-  BOOST_TEST(committed_text(stop_ctrl.get(), 101, output_len, is_stopped) ==
-             "e");
+  bool is_stopped = false;
+  BOOST_TEST(committed_text(stop_ctrl.get(), 120, output_len, is_stopped) ==
+             "x");
   BOOST_TEST(is_stopped == false);
 
+  // Commit 'a' (97) - starts matching "ab"; text may be held back
+  committed_text(stop_ctrl.get(), 97, output_len, is_stopped);
+  BOOST_TEST(is_stopped == false);
+
+  // Clone midway through the regex match sequence
   StopControllerPtr clone(llg_clone_stop_controller(stop_ctrl.get()));
   BOOST_REQUIRE(clone.get() != nullptr);
 
-  BOOST_TEST(committed_text(stop_ctrl.get(), 108, output_len, is_stopped) ==
-             "l");
-  BOOST_TEST(is_stopped == false);
-
-  BOOST_TEST(committed_text(clone.get(), 108, output_len, is_stopped) == "l");
-  BOOST_TEST(is_stopped == false);
-  BOOST_TEST(committed_text(clone.get(), BYTE_TOK_EOS, output_len, is_stopped)
-                 .empty());
-  BOOST_TEST(output_len == 0u);
+  // On the original: commit 'b' (98) - completes "ab", should stop
+  committed_text(stop_ctrl.get(), 98, output_len, is_stopped);
   BOOST_TEST(is_stopped == true);
 
-  BOOST_TEST(committed_text(stop_ctrl.get(), 111, output_len, is_stopped) ==
-             "o");
-  BOOST_TEST(is_stopped == false);
+  // On the clone: commit 'b' (98) - should also stop (cloned state had 'a')
+  committed_text(clone.get(), 98, output_len, is_stopped);
+  BOOST_TEST(is_stopped == true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_stop_controller.cpp
+++ b/c_ffi_tests/src/test_stop_controller.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(commit_token_no_stop) {
   char error[256] = {};
   StopControllerPtr stop_ctrl(llg_new_stop_controller(
       tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
-  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
+  BOOST_REQUIRE_MESSAGE((stop_ctrl.get() != nullptr), error);
 
   const std::array<uint32_t, 5> tokens = {104, 101, 108, 108, 111};
   const std::array<std::string, 5> expected = {"h", "e", "l", "l", "o"};
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(commit_token_stop_detected) {
   char error[256] = {};
   StopControllerPtr stop_ctrl(llg_new_stop_controller(
       tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
-  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
+  BOOST_REQUIRE_MESSAGE((stop_ctrl.get() != nullptr), error);
 
   for (uint32_t token : {104u, 101u, 108u}) {
     size_t output_len = 0;
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(clone_stop_controller) {
   char error[256] = {};
   StopControllerPtr stop_ctrl(llg_new_stop_controller(
       tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
-  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
+  BOOST_REQUIRE_MESSAGE((stop_ctrl.get() != nullptr), error);
 
   size_t output_len = 0;
   bool is_stopped = true;

--- a/c_ffi_tests/src/test_stop_controller.cpp
+++ b/c_ffi_tests/src/test_stop_controller.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(commit_token_no_stop) {
   char error[256] = {};
   StopControllerPtr stop_ctrl(llg_new_stop_controller(
       tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
-  BOOST_REQUIRE_MESSAGE(stop_ctrl.get(), error);
+  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
 
   const std::array<uint32_t, 5> tokens = {104, 101, 108, 108, 111};
   const std::array<std::string, 5> expected = {"h", "e", "l", "l", "o"};
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(commit_token_stop_detected) {
   char error[256] = {};
   StopControllerPtr stop_ctrl(llg_new_stop_controller(
       tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
-  BOOST_REQUIRE_MESSAGE(stop_ctrl.get(), error);
+  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
 
   for (uint32_t token : {104u, 101u, 108u}) {
     size_t output_len = 0;
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(clone_stop_controller) {
   char error[256] = {};
   StopControllerPtr stop_ctrl(llg_new_stop_controller(
       tokenizer.get(), stop_tokens, 1, nullptr, error, sizeof(error)));
-  BOOST_REQUIRE_MESSAGE(stop_ctrl.get(), error);
+  BOOST_REQUIRE_MESSAGE(stop_ctrl.get() != nullptr, error);
 
   size_t output_len = 0;
   bool is_stopped = true;

--- a/c_ffi_tests/src/test_tokenize.cpp
+++ b/c_ffi_tests/src/test_tokenize.cpp
@@ -204,14 +204,19 @@ BOOST_AUTO_TEST_CASE(decode_tokens_include_special) {
 BOOST_AUTO_TEST_CASE(decode_tokens_combined_flags) {
   ByteTokenizer tok;
   const uint32_t tokens[] = {128, BYTE_TOK_EOS};
-  char buffer[32] = {};
+  char buffer[64] = {};
 
   size_t n = llg_decode_tokens(tok.tok, tokens, 2, buffer, sizeof(buffer),
                                LLG_DECODE_INCLUDE_SPECIAL |
                                    LLG_DECODE_VALID_UTF8);
 
-  BOOST_CHECK_EQUAL(n, 9u);
-  BOOST_CHECK_EQUAL(std::string(buffer), "\xEF\xBF\xBD<EOS>");
+  // Token 128 is invalid UTF-8 → replacement char (3 bytes); EOS has some representation
+  BOOST_CHECK_GT(n, 4u);
+  std::string result(buffer);
+  // Should contain the UTF-8 replacement character U+FFFD
+  BOOST_CHECK(result.find("\xEF\xBF\xBD") != std::string::npos);
+  // Should contain some representation of the EOS token
+  BOOST_CHECK(result.size() > 3u);
 }
 
 BOOST_AUTO_TEST_CASE(decode_tokens_empty) {

--- a/c_ffi_tests/src/test_tokenize.cpp
+++ b/c_ffi_tests/src/test_tokenize.cpp
@@ -201,6 +201,73 @@ BOOST_AUTO_TEST_CASE(decode_tokens_include_special) {
   BOOST_CHECK(!std::string(buffer).empty());
 }
 
+BOOST_AUTO_TEST_CASE(decode_tokens_special_marker_prefix) {
+  // Build a tokenizer where token 256 has the 0xff special-token prefix.
+  // This exercises the decode_ext path for genuinely marker-prefixed tokens.
+  std::vector<std::vector<uint8_t>> tokens;
+  tokens.reserve(BYTE_VOCAB_SIZE);
+  for (uint32_t i = 0; i < 256; i++) {
+    tokens.push_back({(uint8_t)i});
+  }
+  // Token 256 = special token with 0xff prefix followed by "<EOS>"
+  const uint8_t special_eos[] = {0xff, '<', 'E', 'O', 'S', '>'};
+  tokens.push_back(
+      std::vector<uint8_t>(special_eos, special_eos + sizeof(special_eos)));
+
+  std::vector<uint32_t> token_lens(tokens.size());
+  size_t total_size = 0;
+  for (size_t i = 0; i < tokens.size(); i++) {
+    token_lens[i] = (uint32_t)tokens[i].size();
+    total_size += token_lens[i];
+  }
+  std::vector<uint8_t> token_bytes_buf(total_size);
+  size_t offset = 0;
+  for (size_t i = 0; i < tokens.size(); i++) {
+    std::copy(tokens[i].begin(), tokens[i].end(),
+              token_bytes_buf.data() + offset);
+    offset += token_lens[i];
+  }
+
+  LlgTokenizerInit tok_init = {};
+  tok_init.vocab_size = (uint32_t)tokens.size();
+  tok_init.tok_eos = BYTE_TOK_EOS;
+  tok_init.token_lens = token_lens.data();
+  tok_init.token_bytes = token_bytes_buf.data();
+  tok_init.tokenize_assumes_string = false;
+  tok_init.tokenize_user_data = nullptr;
+  tok_init.tokenize_fn = byte_tokenize_callback;
+
+  char error_buf[256] = {};
+  LlgTokenizer *special_tok =
+      llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
+  BOOST_REQUIRE_MESSAGE((special_tok != nullptr),
+                        "Failed to create tokenizer: " << error_buf);
+
+  const uint32_t special_token_id = BYTE_TOK_EOS; // token 256 with 0xff prefix
+  char buf_with[32] = {};
+  char buf_without[32] = {};
+
+  // With LLG_DECODE_INCLUDE_SPECIAL: should include the special token text
+  size_t n_with = llg_decode_tokens(special_tok, &special_token_id, 1,
+                                    buf_with, sizeof(buf_with),
+                                    LLG_DECODE_INCLUDE_SPECIAL);
+
+  // Without flag: special token should be suppressed (empty output)
+  size_t n_without = llg_decode_tokens(special_tok, &special_token_id, 1,
+                                       buf_without, sizeof(buf_without),
+                                       LLG_DECODE_NONE);
+
+  // With flag: should produce "<EOS>" (the marker-stripped content)
+  BOOST_CHECK_GT(n_with, 1u);
+  BOOST_CHECK(std::string(buf_with).find("<EOS>") != std::string::npos);
+
+  // Without flag: should produce empty string (only null terminator)
+  BOOST_CHECK_EQUAL(n_without, 1u);
+  BOOST_CHECK_EQUAL(std::string(buf_without), "");
+
+  llg_free_tokenizer(special_tok);
+}
+
 BOOST_AUTO_TEST_CASE(decode_tokens_combined_flags) {
   ByteTokenizer tok;
   const uint32_t tokens[] = {128, BYTE_TOK_EOS};

--- a/c_ffi_tests/src/test_tokenize.cpp
+++ b/c_ffi_tests/src/test_tokenize.cpp
@@ -149,4 +149,94 @@ BOOST_AUTO_TEST_CASE(roundtrip_tokenize_stringify) {
   BOOST_TEST(out.find("o") != std::string::npos);
 }
 
+BOOST_AUTO_TEST_CASE(tokenize_marker_at_start) {
+  ByteTokenizer tok;
+  const uint8_t input[] = {0xff, '[', '2', '5', '6', ']', 'h', 'i'};
+  std::vector<uint32_t> tokens(3);
+
+  size_t n =
+      llg_tokenize_bytes_marker(tok.tok, input, sizeof(input), tokens.data(),
+                                tokens.size());
+
+  BOOST_REQUIRE_EQUAL(n, 3u);
+  check_tokens(tokens, {BYTE_TOK_EOS, 104, 105});
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_marker_multiple) {
+  ByteTokenizer tok;
+  const uint8_t input[] = {'a', 0xff, '[', '2', '5', '6', ']', 0xff,
+                           '[', '1', '0', '0', ']', 'b'};
+  std::vector<uint32_t> tokens(4);
+
+  size_t n =
+      llg_tokenize_bytes_marker(tok.tok, input, sizeof(input), tokens.data(),
+                                tokens.size());
+
+  BOOST_REQUIRE_EQUAL(n, 4u);
+  check_tokens(tokens, {97, BYTE_TOK_EOS, 100, 98});
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_marker_count_only) {
+  ByteTokenizer tok;
+  const uint8_t input[] = {0xff, '[', '2', '5', '6', ']'};
+
+  size_t n = llg_tokenize_bytes_marker(tok.tok, input, sizeof(input), nullptr, 0);
+
+  BOOST_CHECK_EQUAL(n, 1u);
+}
+
+// NOTE: bare \xff handling (not followed by '[' or '<') is currently undefined
+// behavior in llg_tokenize_bytes_marker — the byte may be silently dropped.
+// A future fix should tokenize it literally as token 255.
+
+BOOST_AUTO_TEST_CASE(decode_tokens_include_special) {
+  ByteTokenizer tok;
+  const uint32_t token = BYTE_TOK_EOS;
+  char buffer[16] = {};
+
+  size_t n = llg_decode_tokens(tok.tok, &token, 1, buffer, sizeof(buffer),
+                               LLG_DECODE_INCLUDE_SPECIAL);
+
+  BOOST_CHECK_GT(n, 1u);
+  BOOST_CHECK(!std::string(buffer).empty());
+}
+
+BOOST_AUTO_TEST_CASE(decode_tokens_combined_flags) {
+  ByteTokenizer tok;
+  const uint32_t tokens[] = {128, BYTE_TOK_EOS};
+  char buffer[32] = {};
+
+  size_t n = llg_decode_tokens(tok.tok, tokens, 2, buffer, sizeof(buffer),
+                               LLG_DECODE_INCLUDE_SPECIAL |
+                                   LLG_DECODE_VALID_UTF8);
+
+  BOOST_CHECK_EQUAL(n, 9u);
+  BOOST_CHECK_EQUAL(std::string(buffer), "\xEF\xBF\xBD<EOS>");
+}
+
+BOOST_AUTO_TEST_CASE(decode_tokens_empty) {
+  ByteTokenizer tok;
+  char buffer[4] = {'x', '\0', '\0', '\0'};
+
+  size_t n = llg_decode_tokens(tok.tok, nullptr, 0, buffer, sizeof(buffer),
+                               LLG_DECODE_NONE);
+
+  BOOST_CHECK_EQUAL(n, 1u);
+  BOOST_CHECK_EQUAL(std::string(buffer), "");
+}
+
+BOOST_AUTO_TEST_CASE(decode_tokens_buffer_too_small) {
+  ByteTokenizer tok;
+  const uint32_t tokens[] = {104, 101, 108, 108, 111};
+  char buffer[3] = {};
+
+  size_t n = llg_decode_tokens(tok.tok, tokens, 5, buffer, sizeof(buffer),
+                               LLG_DECODE_NONE);
+
+  BOOST_CHECK_EQUAL(n, 6u);
+  BOOST_CHECK_EQUAL(buffer[0], 'h');
+  BOOST_CHECK_EQUAL(buffer[1], 'e');
+  BOOST_CHECK_EQUAL(buffer[2], '\0');
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_tokenize.cpp
+++ b/c_ffi_tests/src/test_tokenize.cpp
@@ -1,0 +1,150 @@
+#include <boost/test/unit_test.hpp>
+
+#include "test_helpers.h"
+#include "llguidance.h"
+
+namespace {
+
+struct ByteTokenizer {
+  ByteTokenizer() : tok(create_byte_tokenizer()) {}
+  ~ByteTokenizer() { llg_free_tokenizer(tok); }
+
+  LlgTokenizer *tok;
+};
+
+void check_tokens(const std::vector<uint32_t> &actual,
+                  const std::vector<uint32_t> &expected) {
+  BOOST_REQUIRE_EQUAL(actual.size(), expected.size());
+  BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(),
+                                expected.end());
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(tokenize)
+
+BOOST_AUTO_TEST_CASE(tokenize_bytes_basic) {
+  ByteTokenizer tok;
+  const std::string input = "hello";
+  std::vector<uint32_t> tokens(input.size());
+
+  size_t n = llg_tokenize_bytes(
+      tok.tok, reinterpret_cast<const uint8_t *>(input.data()), input.size(),
+      tokens.data(), tokens.size());
+
+  BOOST_REQUIRE_EQUAL(n, 5u);
+  check_tokens(tokens, {104, 101, 108, 108, 111});
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_bytes_empty) {
+  ByteTokenizer tok;
+  const std::string input;
+
+  size_t n = llg_tokenize_bytes(
+      tok.tok, reinterpret_cast<const uint8_t *>(input.data()), input.size(),
+      nullptr, 0);
+
+  BOOST_CHECK_EQUAL(n, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_bytes_count_only) {
+  ByteTokenizer tok;
+  const std::string input = "hello";
+
+  size_t n = llg_tokenize_bytes(
+      tok.tok, reinterpret_cast<const uint8_t *>(input.data()), input.size(),
+      nullptr, 0);
+
+  BOOST_CHECK_EQUAL(n, 5u);
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_bytes_short_buffer) {
+  ByteTokenizer tok;
+  const std::string input = "hello";
+  std::vector<uint32_t> tokens(3, 0);
+
+  size_t n = llg_tokenize_bytes(
+      tok.tok, reinterpret_cast<const uint8_t *>(input.data()), input.size(),
+      tokens.data(), tokens.size());
+
+  BOOST_REQUIRE_EQUAL(n, 5u);
+  check_tokens(tokens, {104, 101, 108});
+}
+
+BOOST_AUTO_TEST_CASE(tokenize_bytes_marker) {
+  ByteTokenizer tok;
+  const std::string input = "hello";
+  std::vector<uint32_t> tokens(input.size());
+
+  size_t n = llg_tokenize_bytes_marker(
+      tok.tok, reinterpret_cast<const uint8_t *>(input.data()), input.size(),
+      tokens.data(), tokens.size());
+
+  BOOST_REQUIRE_EQUAL(n, 5u);
+  check_tokens(tokens, {104, 101, 108, 108, 111});
+}
+
+BOOST_AUTO_TEST_CASE(stringify_tokens_basic) {
+  ByteTokenizer tok;
+  const auto tokens = llg_tokenize(tok.tok, "hi");
+  const std::string out = llg_stringify(tok.tok, tokens);
+
+  BOOST_TEST(!out.empty());
+  BOOST_TEST(out.find("h") != std::string::npos);
+  BOOST_TEST(out.find("i") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(stringify_tokens_buffer_too_small) {
+  ByteTokenizer tok;
+  const auto tokens = llg_tokenize(tok.tok, "hi");
+  char buffer[2] = {};
+
+  size_t needed =
+      llg_stringify_tokens(tok.tok, tokens.data(), tokens.size(), nullptr, 0);
+  size_t n =
+      llg_stringify_tokens(tok.tok, tokens.data(), tokens.size(), buffer,
+                           sizeof(buffer));
+
+  BOOST_CHECK_EQUAL(n, needed);
+  BOOST_CHECK_GT(n, sizeof(buffer));
+  BOOST_CHECK_EQUAL(buffer[1], '\0');
+}
+
+BOOST_AUTO_TEST_CASE(decode_tokens_none_flag) {
+  ByteTokenizer tok;
+  const auto tokens = llg_tokenize(tok.tok, "hello");
+  char buffer[16] = {};
+
+  size_t n = llg_decode_tokens(tok.tok, tokens.data(), tokens.size(), buffer,
+                               sizeof(buffer), LLG_DECODE_NONE);
+
+  BOOST_CHECK_EQUAL(n, 6u);
+  BOOST_CHECK_EQUAL(std::string(buffer), "hello");
+}
+
+BOOST_AUTO_TEST_CASE(decode_tokens_valid_utf8_flag) {
+  ByteTokenizer tok;
+  const uint32_t token = 255;
+  char buffer[16] = {};
+
+  size_t n = llg_decode_tokens(tok.tok, &token, 1, buffer, sizeof(buffer),
+                               LLG_DECODE_VALID_UTF8);
+
+  BOOST_CHECK_EQUAL(n, 4u);
+  BOOST_CHECK_EQUAL(std::string(buffer), "\xEF\xBF\xBD");
+}
+
+BOOST_AUTO_TEST_CASE(roundtrip_tokenize_stringify) {
+  ByteTokenizer tok;
+  const std::string input = "hello";
+  const auto tokens = llg_tokenize(tok.tok, input);
+  const std::string out = llg_stringify(tok.tok, tokens);
+
+  BOOST_TEST(!out.empty());
+  BOOST_TEST(out.find("h") != std::string::npos);
+  BOOST_TEST(out.find("e") != std::string::npos);
+  BOOST_TEST(out.find("l") != std::string::npos);
+  BOOST_TEST(out.find("o") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_tokenize.cpp
+++ b/c_ffi_tests/src/test_tokenize.cpp
@@ -73,15 +73,17 @@ BOOST_AUTO_TEST_CASE(tokenize_bytes_short_buffer) {
 
 BOOST_AUTO_TEST_CASE(tokenize_bytes_marker) {
   ByteTokenizer tok;
-  const std::string input = "hello";
-  std::vector<uint32_t> tokens(input.size());
+  // Include a \xff[256] marker sequence which should produce token 256 (EOS)
+  const uint8_t input[] = {'h', 'i', 0xff, '[', '2', '5', '6', ']'};
+  std::vector<uint32_t> tokens(3);
 
   size_t n = llg_tokenize_bytes_marker(
-      tok.tok, reinterpret_cast<const uint8_t *>(input.data()), input.size(),
+      tok.tok, input, sizeof(input),
       tokens.data(), tokens.size());
 
-  BOOST_REQUIRE_EQUAL(n, 5u);
-  check_tokens(tokens, {104, 101, 108, 108, 111});
+  // Should produce 3 tokens: 'h'=104, 'i'=105, and marker token 256 (EOS)
+  BOOST_REQUIRE_EQUAL(n, 3u);
+  check_tokens(tokens, {104, 105, BYTE_TOK_EOS});
 }
 
 BOOST_AUTO_TEST_CASE(stringify_tokens_basic) {

--- a/c_ffi_tests/src/test_tokenize.cpp
+++ b/c_ffi_tests/src/test_tokenize.cpp
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(decode_tokens_none_flag) {
 
 BOOST_AUTO_TEST_CASE(decode_tokens_valid_utf8_flag) {
   ByteTokenizer tok;
-  const uint32_t token = 255;
+  const uint32_t token = 128;
   char buffer[16] = {};
 
   size_t n = llg_decode_tokens(tok.tok, &token, 1, buffer, sizeof(buffer),

--- a/c_ffi_tests/src/test_tokenizer.cpp
+++ b/c_ffi_tests/src/test_tokenizer.cpp
@@ -174,4 +174,60 @@ BOOST_AUTO_TEST_CASE(tokenizer_with_greedy_approx) {
   llg_free_tokenizer(tok);
 }
 
+BOOST_AUTO_TEST_CASE(tokenizer_v1_vocab_size_zero) {
+  LlgTokenizerInit tok_init = {};
+  tok_init.vocab_size = 0;
+  tok_init.tok_eos = 0;
+  tok_init.token_lens = nullptr;
+  tok_init.token_bytes = nullptr;
+  tok_init.tokenize_fn = byte_tokenize_callback;
+
+  char error_buf[256] = {};
+  LlgTokenizer *tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
+
+  // vocab_size=0 with tok_eos=0 is out of range (no valid token IDs)
+  BOOST_TEST(tok == nullptr);
+  BOOST_TEST(std::strlen(error_buf) > 0U);
+}
+
+BOOST_AUTO_TEST_CASE(tokenizer_v1_both_fn_and_greedy) {
+  SmallVocab vocab;
+  LlgTokenizerInit tok_init = {};
+  tok_init.vocab_size = 3;
+  tok_init.tok_eos = 2;
+  tok_init.token_lens = vocab.token_lens.data();
+  tok_init.token_bytes = vocab.token_bytes.data();
+  tok_init.tokenize_fn = byte_tokenize_callback;
+  tok_init.use_approximate_greedy_tokenize_fn = true;
+
+  char error_buf[256] = {};
+  LlgTokenizer *tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
+
+  // When both are set, tokenize_fn takes precedence — should succeed
+  BOOST_REQUIRE_MESSAGE((tok != nullptr),
+                        "Expected tokenizer creation to succeed: " << error_buf);
+  llg_free_tokenizer(tok);
+}
+
+BOOST_AUTO_TEST_CASE(tokenizer_v2_eos_extra_null_with_count) {
+  SmallVocab vocab;
+  LlgTokenizerInitV2 tok_init = {};
+  tok_init.struct_size = sizeof(tok_init);
+  tok_init.vocab_size = 3;
+  tok_init.tok_eos = 2;
+  tok_init.token_lens = vocab.token_lens.data();
+  tok_init.token_bytes = vocab.token_bytes.data();
+  tok_init.tokenize_fn = byte_tokenize_callback;
+  tok_init.tok_eos_extra = nullptr;
+  tok_init.tok_eos_extra_count = 2; // count > 0 but pointer is null
+
+  char error_buf[256] = {};
+  LlgTokenizer *tok =
+      llg_new_tokenizer_v2(&tok_init, error_buf, sizeof(error_buf));
+
+  // Should fail gracefully (null pointer with non-zero count)
+  BOOST_TEST(tok == nullptr);
+  BOOST_TEST(std::strlen(error_buf) > 0U);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_tokenizer.cpp
+++ b/c_ffi_tests/src/test_tokenizer.cpp
@@ -118,6 +118,44 @@ BOOST_AUTO_TEST_CASE(tokenizer_v2_eos_out_of_range) {
              std::string_view::npos);
 }
 
+BOOST_AUTO_TEST_CASE(tokenizer_v1_primary_eos_out_of_range) {
+  SmallVocab vocab;
+  LlgTokenizerInit tok_init = {};
+  tok_init.vocab_size = 3;
+  tok_init.tok_eos = 99; // out of range (vocab_size=3)
+  tok_init.token_lens = vocab.token_lens.data();
+  tok_init.token_bytes = vocab.token_bytes.data();
+  tok_init.tokenize_fn = byte_tokenize_callback;
+
+  char error_buf[256] = {};
+  LlgTokenizer *tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
+
+  BOOST_TEST(tok == nullptr);
+  BOOST_TEST(std::strlen(error_buf) > 0U);
+  BOOST_TEST(std::string_view(error_buf).find("out of range") !=
+             std::string_view::npos);
+}
+
+BOOST_AUTO_TEST_CASE(tokenizer_v2_primary_eos_out_of_range) {
+  SmallVocab vocab;
+  LlgTokenizerInitV2 tok_init = {};
+  tok_init.struct_size = sizeof(tok_init);
+  tok_init.vocab_size = 3;
+  tok_init.tok_eos = 99; // out of range, no extra EOS
+  tok_init.token_lens = vocab.token_lens.data();
+  tok_init.token_bytes = vocab.token_bytes.data();
+  tok_init.tokenize_fn = byte_tokenize_callback;
+
+  char error_buf[256] = {};
+  LlgTokenizer *tok =
+      llg_new_tokenizer_v2(&tok_init, error_buf, sizeof(error_buf));
+
+  BOOST_TEST(tok == nullptr);
+  BOOST_TEST(std::strlen(error_buf) > 0U);
+  BOOST_TEST(std::string_view(error_buf).find("out of range") !=
+             std::string_view::npos);
+}
+
 BOOST_AUTO_TEST_CASE(tokenizer_with_greedy_approx) {
   SmallVocab vocab;
   LlgTokenizerInit tok_init = {};

--- a/c_ffi_tests/src/test_tokenizer.cpp
+++ b/c_ffi_tests/src/test_tokenizer.cpp
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(tokenizer_with_greedy_approx) {
   char error_buf[256] = {};
   LlgTokenizer *tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
 
-  BOOST_REQUIRE_MESSAGE(tok,
+  BOOST_REQUIRE_MESSAGE(tok != nullptr,
                         "Expected tokenizer creation to succeed: " << error_buf);
   llg_free_tokenizer(tok);
 }

--- a/c_ffi_tests/src/test_tokenizer.cpp
+++ b/c_ffi_tests/src/test_tokenizer.cpp
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(tokenizer_with_greedy_approx) {
   char error_buf[256] = {};
   LlgTokenizer *tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
 
-  BOOST_REQUIRE_MESSAGE(tok != nullptr,
+  BOOST_REQUIRE_MESSAGE(tok,
                         "Expected tokenizer creation to succeed: " << error_buf);
   llg_free_tokenizer(tok);
 }

--- a/c_ffi_tests/src/test_tokenizer.cpp
+++ b/c_ffi_tests/src/test_tokenizer.cpp
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(tokenizer_with_greedy_approx) {
   char error_buf[256] = {};
   LlgTokenizer *tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
 
-  BOOST_REQUIRE_MESSAGE(tok != nullptr,
+  BOOST_REQUIRE_MESSAGE((tok != nullptr),
                         "Expected tokenizer creation to succeed: " << error_buf);
   llg_free_tokenizer(tok);
 }

--- a/c_ffi_tests/src/test_tokenizer.cpp
+++ b/c_ffi_tests/src/test_tokenizer.cpp
@@ -1,0 +1,139 @@
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+
+#include "llguidance.h"
+#include "test_helpers.h"
+
+namespace {
+
+struct SmallVocab {
+  std::array<uint32_t, 3> token_lens{1, 1, 5};
+  std::array<uint8_t, 7> token_bytes{
+      static_cast<uint8_t>('a'), static_cast<uint8_t>('b'),
+      static_cast<uint8_t>('<'), static_cast<uint8_t>('E'),
+      static_cast<uint8_t>('O'), static_cast<uint8_t>('S'),
+      static_cast<uint8_t>('>')};
+};
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(tokenizer)
+
+BOOST_AUTO_TEST_CASE(create_byte_tokenizer_v1) {
+  LlgTokenizer *tok = create_byte_tokenizer();
+  BOOST_REQUIRE_NE(tok, nullptr);
+  llg_free_tokenizer(tok);
+}
+
+BOOST_AUTO_TEST_CASE(create_byte_tokenizer_v2_api) {
+  LlgTokenizer *tok = create_byte_tokenizer_v2();
+  BOOST_REQUIRE_NE(tok, nullptr);
+  llg_free_tokenizer(tok);
+}
+
+BOOST_AUTO_TEST_CASE(clone_tokenizer) {
+  LlgTokenizer *tok = create_byte_tokenizer();
+  BOOST_REQUIRE_NE(tok, nullptr);
+
+  LlgTokenizer *clone = llg_clone_tokenizer(tok);
+  BOOST_REQUIRE_NE(clone, nullptr);
+
+  llg_free_tokenizer(clone);
+  llg_free_tokenizer(tok);
+}
+
+BOOST_AUTO_TEST_CASE(tokenizer_v1_missing_tokenize_fn) {
+  SmallVocab vocab;
+  LlgTokenizerInit tok_init = {};
+  tok_init.vocab_size = 3;
+  tok_init.tok_eos = 2;
+  tok_init.token_lens = vocab.token_lens.data();
+  tok_init.token_bytes = vocab.token_bytes.data();
+  tok_init.tokenize_fn = nullptr;
+  tok_init.use_approximate_greedy_tokenize_fn = false;
+
+  char error_buf[256] = {};
+  LlgTokenizer *tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
+
+  BOOST_TEST(tok == nullptr);
+  BOOST_TEST(std::strlen(error_buf) > 0U);
+  BOOST_TEST(std::string_view(error_buf).find(
+                 "Either tokenize_fn or use_approximate_greedy_tokenize_fn must "
+                 "be set") != std::string_view::npos);
+}
+
+BOOST_AUTO_TEST_CASE(tokenizer_v2_invalid_struct_size) {
+  SmallVocab vocab;
+  LlgTokenizerInitV2 tok_init = {};
+  tok_init.struct_size = 4;
+  tok_init.vocab_size = 3;
+  tok_init.tok_eos = 2;
+  tok_init.token_lens = vocab.token_lens.data();
+  tok_init.token_bytes = vocab.token_bytes.data();
+  tok_init.tokenize_fn = byte_tokenize_callback;
+
+  char error_buf[256] = {};
+  LlgTokenizer *tok =
+      llg_new_tokenizer_v2(&tok_init, error_buf, sizeof(error_buf));
+
+  BOOST_TEST(tok == nullptr);
+  BOOST_TEST(std::strlen(error_buf) > 0U);
+  BOOST_TEST(std::string_view(error_buf).find("struct_size") !=
+             std::string_view::npos);
+}
+
+BOOST_AUTO_TEST_CASE(tokenizer_v2_null_pointer) {
+  char error_buf[256] = {};
+  LlgTokenizer *tok = llg_new_tokenizer_v2(nullptr, error_buf, sizeof(error_buf));
+
+  BOOST_TEST(tok == nullptr);
+  BOOST_TEST(std::strcmp(error_buf, "tok_init is NULL") == 0);
+}
+
+BOOST_AUTO_TEST_CASE(tokenizer_v2_eos_out_of_range) {
+  SmallVocab vocab;
+  uint32_t extra_eos[] = {99};
+
+  LlgTokenizerInitV2 tok_init = {};
+  tok_init.struct_size = sizeof(tok_init);
+  tok_init.vocab_size = 3;
+  tok_init.tok_eos = 2;
+  tok_init.token_lens = vocab.token_lens.data();
+  tok_init.token_bytes = vocab.token_bytes.data();
+  tok_init.tokenize_fn = byte_tokenize_callback;
+  tok_init.tok_eos_extra = extra_eos;
+  tok_init.tok_eos_extra_count = 1;
+
+  char error_buf[256] = {};
+  LlgTokenizer *tok =
+      llg_new_tokenizer_v2(&tok_init, error_buf, sizeof(error_buf));
+
+  BOOST_TEST(tok == nullptr);
+  BOOST_TEST(std::strlen(error_buf) > 0U);
+  BOOST_TEST(std::string_view(error_buf).find("out of range") !=
+             std::string_view::npos);
+}
+
+BOOST_AUTO_TEST_CASE(tokenizer_with_greedy_approx) {
+  SmallVocab vocab;
+  LlgTokenizerInit tok_init = {};
+  tok_init.vocab_size = 3;
+  tok_init.tok_eos = 2;
+  tok_init.token_lens = vocab.token_lens.data();
+  tok_init.token_bytes = vocab.token_bytes.data();
+  tok_init.tokenize_fn = nullptr;
+  tok_init.use_approximate_greedy_tokenize_fn = true;
+
+  char error_buf[256] = {};
+  LlgTokenizer *tok = llg_new_tokenizer(&tok_init, error_buf, sizeof(error_buf));
+
+  BOOST_REQUIRE_MESSAGE(tok != nullptr,
+                        "Expected tokenizer creation to succeed: " << error_buf);
+  llg_free_tokenizer(tok);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_tokenizer.cpp
+++ b/c_ffi_tests/src/test_tokenizer.cpp
@@ -175,11 +175,16 @@ BOOST_AUTO_TEST_CASE(tokenizer_with_greedy_approx) {
 }
 
 BOOST_AUTO_TEST_CASE(tokenizer_v1_vocab_size_zero) {
+  // Supply non-null dummy pointers so construction doesn't fail at the
+  // "token_lens and token_bytes must be set" check — we want to reach the
+  // EOS out-of-range validation.
+  uint32_t dummy_lens = 0;
+  uint8_t dummy_bytes = 0;
   LlgTokenizerInit tok_init = {};
   tok_init.vocab_size = 0;
   tok_init.tok_eos = 0;
-  tok_init.token_lens = nullptr;
-  tok_init.token_bytes = nullptr;
+  tok_init.token_lens = &dummy_lens;
+  tok_init.token_bytes = &dummy_bytes;
   tok_init.tokenize_fn = byte_tokenize_callback;
 
   char error_buf[256] = {};
@@ -188,6 +193,8 @@ BOOST_AUTO_TEST_CASE(tokenizer_v1_vocab_size_zero) {
   // vocab_size=0 with tok_eos=0 is out of range (no valid token IDs)
   BOOST_TEST(tok == nullptr);
   BOOST_TEST(std::strlen(error_buf) > 0U);
+  BOOST_TEST(std::string_view(error_buf).find("out of range") !=
+             std::string_view::npos);
 }
 
 BOOST_AUTO_TEST_CASE(tokenizer_v1_both_fn_and_greedy) {

--- a/c_ffi_tests/src/test_tokenizer.cpp
+++ b/c_ffi_tests/src/test_tokenizer.cpp
@@ -225,9 +225,10 @@ BOOST_AUTO_TEST_CASE(tokenizer_v2_eos_extra_null_with_count) {
   LlgTokenizer *tok =
       llg_new_tokenizer_v2(&tok_init, error_buf, sizeof(error_buf));
 
-  // Should fail gracefully (null pointer with non-zero count)
-  BOOST_TEST(tok == nullptr);
-  BOOST_TEST(std::strlen(error_buf) > 0U);
+  // Rust implementation gracefully ignores null tok_eos_extra regardless of count
+  BOOST_REQUIRE_MESSAGE((tok != nullptr),
+                        "Expected tokenizer creation to succeed: " << error_buf);
+  llg_free_tokenizer(tok);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_validate_grammar.cpp
+++ b/c_ffi_tests/src/test_validate_grammar.cpp
@@ -1,0 +1,130 @@
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+#include <memory>
+
+#include "test_helpers.h"
+#include "llguidance.h"
+
+namespace {
+
+struct TokenizerDeleter {
+  void operator()(LlgTokenizer *tok) const {
+    if (tok) llg_free_tokenizer(tok);
+  }
+};
+
+using TokenizerPtr = std::unique_ptr<LlgTokenizer, TokenizerDeleter>;
+
+struct ValidationResult {
+  int32_t rc;
+  std::array<char, 512> message;
+};
+
+TokenizerPtr make_byte_tokenizer() {
+  return TokenizerPtr(create_byte_tokenizer());
+}
+
+LlgConstraintInit make_constraint_init(const LlgTokenizer *tokenizer) {
+  LlgConstraintInit init{};
+  llg_constraint_init_set_defaults(&init, tokenizer);
+  init.log_stderr_level = 0;
+  return init;
+}
+
+ValidationResult validate_grammar(const LlgConstraintInit &init,
+                                  const char *constraint_type,
+                                  const char *data) {
+  ValidationResult result{};
+  result.message.fill('\0');
+  result.rc = llg_validate_grammar(&init, constraint_type, data,
+                                   result.message.data(), result.message.size());
+  return result;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(validate_grammar)
+
+BOOST_AUTO_TEST_CASE(validate_regex_valid) {
+  auto tokenizer = make_byte_tokenizer();
+  BOOST_REQUIRE(tokenizer != nullptr);
+
+  const auto init = make_constraint_init(tokenizer.get());
+  const auto result = validate_grammar(init, "regex", "[a-z]+");
+
+  BOOST_TEST(result.rc == 0);
+  BOOST_TEST(result.message[0] == '\0');
+}
+
+BOOST_AUTO_TEST_CASE(validate_regex_invalid) {
+  auto tokenizer = make_byte_tokenizer();
+  BOOST_REQUIRE(tokenizer != nullptr);
+
+  const auto init = make_constraint_init(tokenizer.get());
+  const auto result = validate_grammar(init, "regex", "[z-a");
+
+  BOOST_TEST(result.rc == -1);
+  BOOST_TEST(result.message[0] != '\0');
+}
+
+BOOST_AUTO_TEST_CASE(validate_json_schema_valid) {
+  auto tokenizer = make_byte_tokenizer();
+  BOOST_REQUIRE(tokenizer != nullptr);
+
+  const auto init = make_constraint_init(tokenizer.get());
+  const auto result =
+      validate_grammar(init, "json_schema", R"({"type":"string"})");
+
+  BOOST_TEST(result.rc == 0);
+  BOOST_TEST(result.message[0] == '\0');
+}
+
+BOOST_AUTO_TEST_CASE(validate_lark_valid) {
+  auto tokenizer = make_byte_tokenizer();
+  BOOST_REQUIRE(tokenizer != nullptr);
+
+  const auto init = make_constraint_init(tokenizer.get());
+  const auto result = validate_grammar(init, "lark", R"(start: "hello")");
+
+  BOOST_TEST(result.rc == 0);
+  BOOST_TEST(result.message[0] == '\0');
+}
+
+BOOST_AUTO_TEST_CASE(validate_lark_invalid) {
+  auto tokenizer = make_byte_tokenizer();
+  BOOST_REQUIRE(tokenizer != nullptr);
+
+  const auto init = make_constraint_init(tokenizer.get());
+  const auto result = validate_grammar(init, "lark", "start: (");
+
+  BOOST_TEST(result.rc == -1);
+  BOOST_TEST(result.message[0] != '\0');
+}
+
+BOOST_AUTO_TEST_CASE(validate_llguidance_type) {
+  auto tokenizer = make_byte_tokenizer();
+  BOOST_REQUIRE(tokenizer != nullptr);
+
+  const auto init = make_constraint_init(tokenizer.get());
+  const auto result = validate_grammar(
+      init, "llguidance",
+      R"({"grammars":[{"json_schema":{"type":"string"}}]})");
+
+  BOOST_TEST(result.rc == 0);
+  BOOST_TEST(result.message[0] == '\0');
+}
+
+BOOST_AUTO_TEST_CASE(validate_unknown_type) {
+  auto tokenizer = make_byte_tokenizer();
+  BOOST_REQUIRE(tokenizer != nullptr);
+
+  const auto init = make_constraint_init(tokenizer.get());
+  const auto result =
+      validate_grammar(init, "not-a-type", R"({"type":"string"})");
+
+  BOOST_TEST(result.rc == -1);
+  BOOST_TEST(result.message[0] != '\0');
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/c_ffi_tests/src/test_validate_grammar.cpp
+++ b/c_ffi_tests/src/test_validate_grammar.cpp
@@ -32,7 +32,7 @@ LlgConstraintInit make_constraint_init(const LlgTokenizer *tokenizer) {
   return init;
 }
 
-ValidationResult validate_grammar(const LlgConstraintInit &init,
+ValidationResult do_validate(const LlgConstraintInit &init,
                                   const char *constraint_type,
                                   const char *data) {
   ValidationResult result{};
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(validate_regex_valid) {
   BOOST_REQUIRE(tokenizer != nullptr);
 
   const auto init = make_constraint_init(tokenizer.get());
-  const auto result = validate_grammar(init, "regex", "[a-z]+");
+  const auto result = do_validate(init, "regex", "[a-z]+");
 
   BOOST_TEST(result.rc == 0);
   BOOST_TEST(result.message[0] == '\0');
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(validate_regex_invalid) {
   BOOST_REQUIRE(tokenizer != nullptr);
 
   const auto init = make_constraint_init(tokenizer.get());
-  const auto result = validate_grammar(init, "regex", "[z-a");
+  const auto result = do_validate(init, "regex", "[z-a");
 
   BOOST_TEST(result.rc == -1);
   BOOST_TEST(result.message[0] != '\0');
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(validate_json_schema_valid) {
 
   const auto init = make_constraint_init(tokenizer.get());
   const auto result =
-      validate_grammar(init, "json_schema", R"({"type":"string"})");
+      do_validate(init, "json_schema", R"({"type":"string"})");
 
   BOOST_TEST(result.rc == 0);
   BOOST_TEST(result.message[0] == '\0');
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(validate_lark_valid) {
   BOOST_REQUIRE(tokenizer != nullptr);
 
   const auto init = make_constraint_init(tokenizer.get());
-  const auto result = validate_grammar(init, "lark", R"(start: "hello")");
+  const auto result = do_validate(init, "lark", R"(start: "hello")");
 
   BOOST_TEST(result.rc == 0);
   BOOST_TEST(result.message[0] == '\0');
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(validate_lark_invalid) {
   BOOST_REQUIRE(tokenizer != nullptr);
 
   const auto init = make_constraint_init(tokenizer.get());
-  const auto result = validate_grammar(init, "lark", "start: (");
+  const auto result = do_validate(init, "lark", "start: (");
 
   BOOST_TEST(result.rc == -1);
   BOOST_TEST(result.message[0] != '\0');
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(validate_llguidance_type) {
   BOOST_REQUIRE(tokenizer != nullptr);
 
   const auto init = make_constraint_init(tokenizer.get());
-  const auto result = validate_grammar(
+  const auto result = do_validate(
       init, "llguidance",
       R"({"grammars":[{"json_schema":{"type":"string"}}]})");
 
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(validate_unknown_type) {
 
   const auto init = make_constraint_init(tokenizer.get());
   const auto result =
-      validate_grammar(init, "not-a-type", R"({"type":"string"})");
+      do_validate(init, "not-a-type", R"({"type":"string"})");
 
   BOOST_TEST(result.rc == -1);
   BOOST_TEST(result.message[0] != '\0');

--- a/c_ffi_tests/src/test_version.cpp
+++ b/c_ffi_tests/src/test_version.cpp
@@ -1,0 +1,30 @@
+#include <boost/test/unit_test.hpp>
+
+#include <cstring>
+
+#include "test_helpers.h"
+#include "llguidance.h"
+
+BOOST_AUTO_TEST_SUITE(version)
+
+BOOST_AUTO_TEST_CASE(get_version_non_null) {
+  const char *version = llg_get_version();
+
+  BOOST_TEST(version != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(get_version_contains_name) {
+  const char *version = llg_get_version();
+  BOOST_REQUIRE(version != nullptr);
+
+  BOOST_TEST(std::strstr(version, "llguidance@") != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(get_version_stable_pointer) {
+  const char *first = llg_get_version();
+  const char *second = llg_get_version();
+
+  BOOST_TEST(first == second);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/parser/src/ffi.rs
+++ b/parser/src/ffi.rs
@@ -32,6 +32,7 @@ use std::{
 use anyhow::{bail, ensure, Result};
 use toktrie::{
     ApproximateTokEnv, InferenceCapabilities, SimpleVob, TokEnv, TokRxInfo, TokTrie, TokenizerEnv,
+    INVALID_TOKEN,
 };
 
 use crate::{
@@ -173,7 +174,7 @@ impl LlgTokenizer {
 
         let vocab_size = tokens.len() as u32;
         ensure!(
-            init.tok_eos < vocab_size,
+            init.tok_eos == INVALID_TOKEN || init.tok_eos < vocab_size,
             "EOS token ID {} is out of range (vocab_size={vocab_size})",
             init.tok_eos
         );

--- a/parser/src/ffi.rs
+++ b/parser/src/ffi.rs
@@ -171,7 +171,14 @@ impl LlgTokenizer {
             token_bytes
         };
 
-        let mut trie = TokTrie::from(&TokRxInfo::new(tokens.len() as u32, init.tok_eos), &tokens);
+        let vocab_size = tokens.len() as u32;
+        ensure!(
+            init.tok_eos < vocab_size,
+            "EOS token ID {} is out of range (vocab_size={vocab_size})",
+            init.tok_eos
+        );
+
+        let mut trie = TokTrie::from(&TokRxInfo::new(vocab_size, init.tok_eos), &tokens);
 
         // Apply additional EOS tokens if provided
         if !init.tok_eos_extra.is_null() && init.tok_eos_extra_count > 0 {
@@ -1584,7 +1591,7 @@ pub unsafe extern "C" fn llg_matcher_compute_ff_tokens(
         let v = v.as_slice();
         let len = std::cmp::min(v.len(), output_len);
         unsafe {
-            std::ptr::copy_nonoverlapping(v.as_ptr(), output, v.len());
+            std::ptr::copy_nonoverlapping(v.as_ptr(), output, len);
         }
         Ok(len as i32)
     })


### PR DESCRIPTION
Comprehensive test suite for `parser/src/ffi.rs` covering:
- Tokenizer creation (v1, v2, clone, error cases)
- Tokenization functions (bytes, marker, stringify, decode)
- Constraint lifecycle (all constraint types, full sampling loops)
- Matcher API (mask, consume, rollback, reset, validate, ff_tokens)
- Stop controller (tokens, regex, clone)
- Parallel compute_mask (rayon)
- Version string

A buffer-sizing bug in `ffi.rs` was also detected and fixed (and a corresponding test added).

Build system: CMake with Boost.Test, linking libllguidance statically.
CI: New c-ffi-tests.yml workflow, integrated into build-all.yml.