### PR TITLE
Accept negative numbers in multipleOf (#222)

### DIFF
--- a/json_stats/expected_maskbench.json
+++ b/json_stats/expected_maskbench.json
@@ -6054,9 +6054,7 @@
   "Github_medium---o46359.json": {},
   "Github_medium---o46365.json": {},
   "Github_medium---o46394.json": {},
-  "Github_medium---o46411.json": {
-    "validation_error": "test #0: token not accepted at ⟦{\"‧included‧Non‧Tax‧able‧Prof‧its‧\":‧100‧0‧.‧0‧,\"‧basis‧Adjust‧ment⟧ * ⟦\":-⟧ * ⟦500‧.‧25‧,\"⟧ mask: TokenSet: 12/128256; ⟨\"⟩ ⟨\"\\n⟩ ⟨\":⟩ ⟨\"\\n\\n⟩ ⟨\":\\n⟩ ⟨\"\\r\\n⟩ ⟨\"\\n\\n\\n⟩ ⟨\"\\r\\n\\r\\n⟩ ⟨\":\\r\\n⟩ ⟨\"\\n\\n\\n\\n⟩ ⟨\":\\n\\n⟩ ⟨\"\\r\\n\\r\\n\\r\\n⟩"
-  },
+  "Github_medium---o46411.json": {},
   "Github_medium---o46412.json": {},
   "Github_medium---o46413.json": {},
   "Github_medium---o46423.json": {},
@@ -11447,9 +11445,7 @@
     "json_error": "Unimplemented keys: [\"uniqueItems\"]"
   },
   "JsonSchemaStore---minecraft-damage-type.json": {},
-  "JsonSchemaStore---minecraft-dimension-type.json": {
-    "validation_error": "test #0: token not accepted at ⟦iling‧\":‧true‧,\"‧ambient‧_light‧\":‧0‧.‧2‧,\"‧fixed‧_time‧\":‧600‧0‧,\"‧pig‧lin‧_safe‧\":‧false‧,\"‧bed‧_work‧s‧\":‧false‧,\"‧resp‧awn‧_anchor‧_work‧s‧\":‧true‧,\"‧has‧_ra‧ids‧\":‧false‧,\"‧logical‧_height‧\":‧128‧,\"‧min‧_y⟧ * ⟦\":-⟧ * ⟦64‧,\"‧height‧\":⟧ mask: TokenSet: 123243/128256; ALL EXCEPT EOS ≺HEX[a1]≻ ≺HEX[a2]≻ ≺HEX[a3]≻ ≺HEX[a4]≻ ≺HEX[a5]≻ ≺HEX[a6]≻ ≺HEX[a7]≻ ≺HEX[a8]≻ ≺HEX[a9]≻ ≺HEX[aa]≻ ≺HEX[ab]≻ ≺HEX[ac]≻ ≺HEX[ae]≻ ≺HEX[af]≻ ≺HEX[b0]≻ ≺HEX[b1]≻ ≺HEX[b2]≻ ≺HEX[b3]≻ ≺HEX[b4]≻ ≺HEX[b5]≻ ≺HEX[b6]≻ ≺HEX[b7]≻ ≺HEX[b8]≻ ≺HEX[b9]≻ ≺HEX[ba]≻ ≺HEX[bb]≻ ≺HEX[bc]≻ ≺HEX[bd]≻ ≺HEX[be]≻ ≺HEX[bf]≻ ≺HEX[c0]≻ ≺HEX[c1]≻ ≺HEX[f5]≻ ≺HEX[f6]≻ ≺HEX[f7]≻ ≺HEX[f8]≻ ≺HEX[f9]≻ ≺HEX[fa]≻ ≺HEX[fb]≻ ≺HEX[fc]≻ ≺HEX[fd]≻ ≺HEX[fe]≻ �.. (84 more)"
-  },
+  "JsonSchemaStore---minecraft-dimension-type.json": {},
   "JsonSchemaStore---minecraft-dimension.json": {
     "json_error": "Unimplemented keys: [\"if\", \"then\"]"
   },

--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -302,7 +302,15 @@ impl Compiler {
         })?;
         let mut ast = RegexAst::Regex(rx);
         if let Some(d) = num.multiple_of.as_ref() {
-            ast = RegexAst::And(vec![ast, RegexAst::MultipleOf(d.coef, d.exp)]);
+            // RegexAst::MultipleOf only matches the unsigned digit sequence, so
+            // allow an optional leading '-' to accept negative multiples (e.g.
+            // -6 for multipleOf 3); divisibility is independent of sign.
+            // https://github.com/guidance-ai/llguidance/issues/222
+            let multiple_of = RegexAst::Concat(vec![
+                RegexAst::Regex("-?".to_string()),
+                RegexAst::MultipleOf(d.coef, d.exp),
+            ]);
+            ast = RegexAst::And(vec![ast, multiple_of]);
         }
         Ok(ast)
     }
@@ -323,7 +331,15 @@ impl Compiler {
             })?;
         let mut ast = RegexAst::Regex(rx);
         if let Some(d) = num.multiple_of.as_ref() {
-            ast = RegexAst::And(vec![ast, RegexAst::MultipleOf(d.coef, d.exp)]);
+            // RegexAst::MultipleOf only matches the unsigned digit sequence, so
+            // allow an optional leading '-' to accept negative multiples (e.g.
+            // -6 for multipleOf 3); divisibility is independent of sign.
+            // https://github.com/guidance-ai/llguidance/issues/222
+            let multiple_of = RegexAst::Concat(vec![
+                RegexAst::Regex("-?".to_string()),
+                RegexAst::MultipleOf(d.coef, d.exp),
+            ]);
+            ast = RegexAst::And(vec![ast, multiple_of]);
         }
         Ok(ast)
     }

--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -302,15 +302,7 @@ impl Compiler {
         })?;
         let mut ast = RegexAst::Regex(rx);
         if let Some(d) = num.multiple_of.as_ref() {
-            // RegexAst::MultipleOf only matches the unsigned digit sequence, so
-            // allow an optional leading '-' to accept negative multiples (e.g.
-            // -6 for multipleOf 3); divisibility is independent of sign.
-            // https://github.com/guidance-ai/llguidance/issues/222
-            let multiple_of = RegexAst::Concat(vec![
-                RegexAst::Regex("-?".to_string()),
-                RegexAst::MultipleOf(d.coef, d.exp),
-            ]);
-            ast = RegexAst::And(vec![ast, multiple_of]);
+            ast = RegexAst::And(vec![ast, signed_multiple_of_ast(d.coef, d.exp)]);
         }
         Ok(ast)
     }
@@ -331,15 +323,7 @@ impl Compiler {
             })?;
         let mut ast = RegexAst::Regex(rx);
         if let Some(d) = num.multiple_of.as_ref() {
-            // RegexAst::MultipleOf only matches the unsigned digit sequence, so
-            // allow an optional leading '-' to accept negative multiples (e.g.
-            // -6 for multipleOf 3); divisibility is independent of sign.
-            // https://github.com/guidance-ai/llguidance/issues/222
-            let multiple_of = RegexAst::Concat(vec![
-                RegexAst::Regex("-?".to_string()),
-                RegexAst::MultipleOf(d.coef, d.exp),
-            ]);
-            ast = RegexAst::And(vec![ast, multiple_of]);
+            ast = RegexAst::And(vec![ast, signed_multiple_of_ast(d.coef, d.exp)]);
         }
         Ok(ast)
     }
@@ -953,6 +937,21 @@ impl Compiler {
         grammars.push(self.builder.string("]"));
         Ok(self.builder.join(&grammars))
     }
+}
+
+/// Build the `multipleOf` regex constraint with sign handling.
+///
+/// derivre's `RegexAst::MultipleOf` matches only the unsigned numeric literal
+/// (the digits, plus a decimal point for non-integer `multipleOf`); it has no
+/// transition for a leading `-`. Allow an optional sign here, otherwise
+/// negative multiples (e.g. `-6` for `multipleOf 3`) would be rejected.
+/// Divisibility is independent of sign.
+/// https://github.com/guidance-ai/llguidance/issues/222
+fn signed_multiple_of_ast(coef: u32, exp: u32) -> RegexAst {
+    RegexAst::Concat(vec![
+        RegexAst::Regex("-?".to_string()),
+        RegexAst::MultipleOf(coef, exp),
+    ])
 }
 
 fn always_non_empty(ast: &RegexAst) -> bool {

--- a/parser/tests/test_json_primitives.rs
+++ b/parser/tests/test_json_primitives.rs
@@ -192,8 +192,9 @@ fn integer_limits_empty() {
 }
 
 #[rstest]
-fn integer_multipleof(#[values(0, 1, 3, 12, 1818, 1819)] test_value: i64) {
-    // See also issue 222: want to add some negative values
+fn integer_multipleof(
+    #[values(-1819, -1818, -12, -3, -2, -1, 0, 1, 3, 12, 1818, 1819)] test_value: i64,
+) {
     const MULTIPLE_OF: i64 = 3;
     let schema = &json!({"type":"integer", "multipleOf": MULTIPLE_OF});
     json_schema_check(schema, &json!(test_value), test_value % MULTIPLE_OF == 0);
@@ -408,15 +409,16 @@ fn number_multipleof(#[case] test_value: f64, #[case] expected_pass: bool) {
 }
 
 #[rstest]
-// Issue 222 #[case(-35.0, true)]
-// Issue 222 #[case(-30.0, false)]
-// Issue 222 #[case(-7.0, true)]
+#[case(-35.0, true)]
+#[case(-30.0, false)]
+#[case(-7.0, true)]
 #[case(0.0, true)]
 #[case(3.5, true)]
 #[case(4.0, false)]
 #[case(325.5, true)]
 #[case(326.5, false)]
-// Issue 222 #[case(3.5e22, true)]
+// scientific notation (3.5e22) is blocked by #216, not #222
+// #[case(3.5e22, true)]
 fn number_multipleof_noninteger(#[case] test_value: f64, #[case] expected_pass: bool) {
     // See also issue 222
     const MULTIPLE_OF: f64 = 3.5;


### PR DESCRIPTION
`RegexAst::MultipleOf` only matches unsigned digits, so And-ing it with the signed range regex rejected all negative values — including valid negative multiples like `-6` for `multipleOf 3`. This wraps it as `Concat(["-?", MultipleOf])`; divisibility is sign-independent and `-?` matches empty for positives (no regression). Adds negative integer cases and re-enables the maintainer-marked negative `3.5` cases.

Scope: this fixes the **sign** facet of #222. Two related facets are left as follow-ups and noted in the tests — (1) integer-valued `multipleOf` (e.g. `3.0`) on `number` still chokes on the decimal point, and (2) scientific notation (`3.5e22`) is #216. Full suite + fmt + clippy clean.