### PR TITLE
[Build] Deal with mypy/numpy issue

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -3,3 +3,11 @@ strict = True
 files = llguidance, torch_tests
 exclude = tmp
 python_version = 3.10
+
+# numpy >= 2.5 ships PEP 695 `type X = ...` aliases in its stubs, which mypy
+# only parses under python_version >= 3.12. We target 3.10 (requires-python
+# >= 3.10), so skip analysing numpy's stubs to avoid a spurious syntax error.
+# Remove this once the minimum supported Python is 3.12.
+[mypy-numpy.*]
+follow_imports = skip
+follow_imports_for_stubs = True


### PR DESCRIPTION
The latest release of `numpy` (2.5) is shipping type hints which only work with Python 3.12 or later, but we still support earlier Python versions.  We configure `mypy` to make its compatibility check against 3.10, so `mypy` gets upset when running a later Python (which will have installed the latest `numpy`). This suppresses checking through `numpy` to avoid this.