### PR TITLE
Honor explicit special=false in ByteTokenizer::from_tokenizer

### DIFF
--- a/toktrie_hf_tokenizers/src/lib.rs
+++ b/toktrie_hf_tokenizers/src/lib.rs
@@ -72,7 +72,29 @@ impl ByteTokenizer {
     /// Creates a [`ByteTokenizer`] from an existing HuggingFace [`Tokenizer`],
     /// applying normalizer and pre-tokenizer fixes and extracting byte-level
     /// token representations.
-    pub fn from_tokenizer(mut hft: Tokenizer) -> Result<ByteTokenizer> {
+    ///
+    /// Added tokens shaped like `<...>` are treated as special tokens even if
+    /// the tokenizer flags them `special = false` (some tokenizers, e.g. Phi-3,
+    /// mislabel their control tokens). Use
+    /// [`ByteTokenizer::from_tokenizer_with_options`] with
+    /// `infer_special_tokens = false` to honor the explicit flag instead.
+    pub fn from_tokenizer(hft: Tokenizer) -> Result<ByteTokenizer> {
+        ByteTokenizer::from_tokenizer_with_options(hft, true)
+    }
+
+    /// Like [`ByteTokenizer::from_tokenizer`], but with explicit control over
+    /// special-token detection for added tokens.
+    ///
+    /// If `infer_special_tokens` is `true`, any added token of the form `<...>`
+    /// is treated as special regardless of its `special` flag (the historical
+    /// default; helps tokenizers that mislabel control tokens). If `false`, only
+    /// the tokenizer's explicit per-token `special` flag is honored, so
+    /// content-carrying markup tokens like `<fcel>` with `special = false` are
+    /// not stripped on decode (see issue #361).
+    pub fn from_tokenizer_with_options(
+        mut hft: Tokenizer,
+        infer_special_tokens: bool,
+    ) -> Result<ByteTokenizer> {
         let mut is_byte_level = false;
         let mut is_byte_fallback = false;
         let mut space_ch = ' ';
@@ -184,12 +206,14 @@ impl ByteTokenizer {
         let mut specials = HashSet::new();
 
         for (id, info) in added.iter() {
-            // Honor the tokenizer's explicit per-token `special` flag. The `<...>`
-            // shape heuristic from #202 only applies on paths that lack a reliable
-            // flag (e.g. GGUF/llamacpp); an explicit `special = false` from the
-            // `tokenizers` crate must win so content-carrying markup tokens are not
-            // dropped on decode. See #361.
-            if info.special {
+            // With `infer_special_tokens`, we treat all added tokens of the form
+            // <...> as special tokens; otherwise the tokenizer's explicit
+            // per-token `special` flag wins (see issue #361).
+            let is_special = info.special
+                || (infer_special_tokens
+                    && info.content.starts_with("<")
+                    && info.content.ends_with(">"));
+            if is_special {
                 match info.content.as_str() {
                     "</s>"
                     | "<|endoftext|>"
@@ -713,8 +737,10 @@ mod tests {
 
     // Like MINIMAL_TOKENIZER_JSON, but with two `<...>`-shaped added tokens: a
     // content token flagged `special = false` and a genuine control token flagged
-    // `special = true`. Used to check that `from_tokenizer` honors the explicit
-    // per-token flag rather than the name shape (see issue #361).
+    // `special = true`. Used to check that `from_tokenizer_with_options` with
+    // `infer_special_tokens = false` honors the explicit per-token flag rather
+    // than the name shape (see issue #361), while the default `from_tokenizer`
+    // keeps inferring specialness from the `<...>` shape.
     const ADDED_TOKENS_TOKENIZER_JSON: &str = r#"{
         "version": "1.0",
         "truncation": null,
@@ -766,9 +792,10 @@ mod tests {
     }"#;
 
     #[test]
-    fn from_tokenizer_honors_explicit_special_false() {
-        let bt = ByteTokenizer::from_tokenizer(
+    fn from_tokenizer_with_options_honors_explicit_special_false() {
+        let bt = ByteTokenizer::from_tokenizer_with_options(
             Tokenizer::from_str(ADDED_TOKENS_TOKENIZER_JSON).unwrap(),
+            false,
         )
         .unwrap();
 
@@ -790,14 +817,45 @@ mod tests {
         let env = ByteTokenizerEnv::new(bt, None).unwrap();
         let trie = env.tok_trie();
 
-        // The content token survives a skip-special decode (this is the regression
-        // from #361 — the buggy heuristic dropped it, yielding b"a").
+        // The content token survives a skip-special decode (this is the case from
+        // #361 — the shape heuristic dropped it, yielding b"a").
         assert_eq!(trie.decode_ext(&[1, 0], false), b"<fcel>a".to_vec());
 
         // The genuine special token is still stripped on skip-special decode.
         assert_eq!(trie.decode_ext(&[2, 0], false), b"a".to_vec());
 
         // With include_special=true, both are kept.
+        assert_eq!(
+            trie.decode_ext(&[1, 2, 0], true),
+            b"<fcel><|im_end|>a".to_vec()
+        );
+    }
+
+    #[test]
+    fn from_tokenizer_default_infers_special_tokens() {
+        // The default constructor keeps the historical behavior: any added token
+        // of the form <...> is treated as special, even with special=false.
+        let bt = ByteTokenizer::from_tokenizer(
+            Tokenizer::from_str(ADDED_TOKENS_TOKENIZER_JSON).unwrap(),
+        )
+        .unwrap();
+
+        // Both angle-bracket added tokens get the special marker.
+        assert_eq!(
+            bt.token_bytes[1][0],
+            TokTrie::SPECIAL_TOKEN_MARKER,
+            "special=false angle-bracket token is still inferred as special by default"
+        );
+        assert_eq!(&bt.token_bytes[1][1..], b"<fcel>");
+        assert_eq!(bt.token_bytes[2][0], TokTrie::SPECIAL_TOKEN_MARKER);
+        assert_eq!(&bt.token_bytes[2][1..], b"<|im_end|>");
+        assert_eq!(bt.tokrx_info().tok_end_of_turn, Some(2));
+
+        let env = ByteTokenizerEnv::new(bt, None).unwrap();
+        let trie = env.tok_trie();
+
+        // Both are stripped on skip-special decode, kept with include_special=true.
+        assert_eq!(trie.decode_ext(&[1, 2, 0], false), b"a".to_vec());
         assert_eq!(
             trie.decode_ext(&[1, 2, 0], true),
             b"<fcel><|im_end|>a".to_vec()

--- a/toktrie_hf_tokenizers/src/lib.rs
+++ b/toktrie_hf_tokenizers/src/lib.rs
@@ -184,8 +184,12 @@ impl ByteTokenizer {
         let mut specials = HashSet::new();
 
         for (id, info) in added.iter() {
-            // we treat all added tokens of the form <...> as special tokens
-            if info.special || (info.content.starts_with("<") && info.content.ends_with(">")) {
+            // Honor the tokenizer's explicit per-token `special` flag. The `<...>`
+            // shape heuristic from #202 only applies on paths that lack a reliable
+            // flag (e.g. GGUF/llamacpp); an explicit `special = false` from the
+            // `tokenizers` crate must win so content-carrying markup tokens are not
+            // dropped on decode. See #361.
+            if info.special {
                 match info.content.as_str() {
                     "</s>"
                     | "<|endoftext|>"
@@ -704,6 +708,99 @@ mod tests {
         assert_eq!(
             bt.token_bytes[0], b" hello",
             "space_ch replacement should convert ▁ to space"
+        );
+    }
+
+    // Like MINIMAL_TOKENIZER_JSON, but with two `<...>`-shaped added tokens: a
+    // content token flagged `special = false` and a genuine control token flagged
+    // `special = true`. Used to check that `from_tokenizer` honors the explicit
+    // per-token flag rather than the name shape (see issue #361).
+    const ADDED_TOKENS_TOKENIZER_JSON: &str = r#"{
+        "version": "1.0",
+        "truncation": null,
+        "padding": null,
+        "added_tokens": [
+            {
+                "id": 1,
+                "content": "<fcel>",
+                "single_word": false,
+                "lstrip": false,
+                "rstrip": false,
+                "normalized": false,
+                "special": false
+            },
+            {
+                "id": 2,
+                "content": "<|im_end|>",
+                "single_word": false,
+                "lstrip": false,
+                "rstrip": false,
+                "normalized": false,
+                "special": true
+            }
+        ],
+        "normalizer": null,
+        "pre_tokenizer": {
+            "type": "ByteLevel",
+            "add_prefix_space": false,
+            "trim_offsets": true
+        },
+        "post_processor": null,
+        "decoder": {
+            "type": "ByteLevel",
+            "add_prefix_space": false,
+            "trim_offsets": true
+        },
+        "model": {
+            "type": "BPE",
+            "dropout": null,
+            "unk_token": null,
+            "continuing_subword_prefix": "",
+            "end_of_word_suffix": "",
+            "fuse_unk": false,
+            "vocab": {
+                "a": 0
+            },
+            "merges": []
+        }
+    }"#;
+
+    #[test]
+    fn from_tokenizer_honors_explicit_special_false() {
+        let bt = ByteTokenizer::from_tokenizer(
+            Tokenizer::from_str(ADDED_TOKENS_TOKENIZER_JSON).unwrap(),
+        )
+        .unwrap();
+
+        // A `<...>`-shaped token with special=false must NOT get the special marker;
+        // it is content and its literal bytes are stored as-is.
+        assert_eq!(
+            bt.token_bytes[1],
+            b"<fcel>".to_vec(),
+            "special=false angle-bracket token must not be marked special"
+        );
+
+        // Its special=true companion is still marked with the 0xff prefix.
+        assert_eq!(bt.token_bytes[2][0], TokTrie::SPECIAL_TOKEN_MARKER);
+        assert_eq!(&bt.token_bytes[2][1..], b"<|im_end|>");
+
+        // Name-based end-of-turn detection still fires for the genuine special token.
+        assert_eq!(bt.tokrx_info().tok_end_of_turn, Some(2));
+
+        let env = ByteTokenizerEnv::new(bt, None).unwrap();
+        let trie = env.tok_trie();
+
+        // The content token survives a skip-special decode (this is the regression
+        // from #361 — the buggy heuristic dropped it, yielding b"a").
+        assert_eq!(trie.decode_ext(&[1, 0], false), b"<fcel>a".to_vec());
+
+        // The genuine special token is still stripped on skip-special decode.
+        assert_eq!(trie.decode_ext(&[2, 0], false), b"a".to_vec());
+
+        // With include_special=true, both are kept.
+        assert_eq!(
+            trie.decode_ext(&[1, 2, 0], true),
+            b"<fcel><|im_end|>a".to_vec()
         );
     }
 }


### PR DESCRIPTION
## Problem

`ByteTokenizer::from_tokenizer` classifies any added token shaped like `<...>` as a special token via a name heuristic, even when the source `tokenizers` object explicitly flags that token `special = false`:

```rust
// we treat all added tokens of the form <...> as special tokens
if info.special || (info.content.starts_with("<") && info.content.ends_with(">")) {
```

Special tokens get `TokTrie::SPECIAL_TOKEN_MARKER` (`0xff`) prepended, and `decode_ext(..., include_special=false)` then drops them. So **content-carrying** markup tokens that happen to be `<...>`-shaped — e.g. PaddleOCR-VL's OTSL table tags `<fcel>`/`<nl>`, or Qwen2.5-VL's `<tool_call>` — get silently stripped on a skip-special decode. That diverges from HuggingFace `transformers` and the Rust `tokenizers` crate, both of which honor the per-token flag:

```
transformers  decode([<fcel>, a], skip_special_tokens=True) -> "<fcel>a"   # honors special=false
tokenizers    decode([<fcel>, a], true)                     -> "<fcel>a"   # honors special=false
llguidance    decode_ext([<fcel>, a], include_special=false) -> "a"        # heuristic dropped <fcel>
```

The `<...>` shape rule was added deliberately in #202 to match the `transformers` path for GGUF, whose metadata often lacks a reliable special flag — and, per review, it also papers over tokenizers (e.g. Phi-3) that mislabel their control tokens, so other users may rely on it.

## Fix (updated per review)

Per the review feedback, the default behavior is now **unchanged**. This PR adds an opt-in constructor variant instead:

```rust
pub fn from_tokenizer_with_options(hft: Tokenizer, infer_special_tokens: bool) -> Result<ByteTokenizer>
```

- `infer_special_tokens = true` — the historical heuristic: any added token of the form `<...>` is treated as special regardless of its `special` flag.
- `infer_special_tokens = false` — only the tokenizer's explicit per-token `special` flag is honored, so content-carrying markup tokens like `<fcel>` survive a skip-special decode (the #361 case).

The existing `from_tokenizer` is re-implemented as a thin wrapper calling the new constructor with `infer_special_tokens = true`, so it is fully backward compatible. `from_file`/`from_json_bytes` (and the Python bindings, which go through them) keep the historical behavior as well.

## Testing

Two tests in the existing inline test module, both against a `tokenizer.json` with two `<...>`-shaped added tokens — `<fcel>` (`special = false`) and `<|im_end|>` (`special = true`):

- `from_tokenizer_with_options_honors_explicit_special_false` — with `infer_special_tokens = false`, the `special = false` token keeps its literal bytes (no `0xff` marker) and round-trips through `decode_ext([1, 0], false)` as `<fcel>a`; the `special = true` companion is still marked and stripped; name-based end-of-turn detection still fires (`tok_end_of_turn == Some(2)`); `include_special = true` keeps both.
- `from_tokenizer_default_infers_special_tokens` — the default constructor still marks **both** angle-bracket tokens special (old behavior preserved), strips both on skip-special decode, and keeps both with `include_special = true`.

```
running 16 tests
test tests::from_tokenizer_with_options_honors_explicit_special_false ... ok
test tests::from_tokenizer_default_infers_special_tokens ... ok
...
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Also ran locally: `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings`, both clean. No FFI or Python-binding surface touched.

Related prior art: #202 (origin of the heuristic), #177 (preserve special tokens in decode).

Fixes #361
