### PR TITLE
Fix rollback for integer-token grammars

### DIFF
--- a/parser/src/earley/mod.rs
+++ b/parser/src/earley/mod.rs
@@ -15,4 +15,5 @@ pub use grammar::{
     SymbolProps,
 };
 pub use parser::{BiasComputer, Parser, ParserError, ParserMetrics, ParserRecognizer, ParserStats};
+pub(crate) use parser::ParserCheckpoint;
 pub use slicer::SlicedBiasComputer;

--- a/parser/src/earley/parser.rs
+++ b/parser/src/earley/parser.rs
@@ -349,6 +349,15 @@ impl Captures {
     }
 }
 
+/// Opaque parser restore point. Constructed only by [`Parser::checkpoint`] and
+/// consumed only by [`Parser::rollback_to`], so callers cannot fabricate an
+/// inconsistent `(byte_len, token_idx)` pair.
+#[derive(Clone, Copy)]
+pub(crate) struct ParserCheckpoint {
+    byte_len: usize,
+    token_idx: usize,
+}
+
 #[derive(Clone)]
 struct ParserState {
     grammar: Arc<CGrammar>,
@@ -1008,25 +1017,34 @@ impl ParserState {
         }
     }
 
-    pub fn rollback(&mut self, n_bytes: usize) -> Result<()> {
-        debug!("rollback: {} bytes", n_bytes);
+    fn checkpoint(&self) -> ParserCheckpoint {
+        ParserCheckpoint {
+            byte_len: self.byte_to_token_idx.len(),
+            token_idx: self.token_idx,
+        }
+    }
+
+    /// Restore parser position to `cp`. Does not restore captures/stats/metrics.
+    fn rollback_to(&mut self, cp: ParserCheckpoint) -> Result<()> {
+        debug!(
+            "rollback_to: {} bytes, token_idx {}",
+            cp.byte_len, cp.token_idx
+        );
         ensure!(self.parser_error.is_none(), "rollback: parser error");
         self.assert_definitive();
         ensure!(
-            n_bytes <= self.byte_to_token_idx.len(),
-            "rollback: too many bytes {} > {}",
-            n_bytes,
+            cp.byte_len <= self.byte_to_token_idx.len(),
+            "rollback: target byte length {} > current {}",
+            cp.byte_len,
             self.byte_to_token_idx.len()
         );
 
-        let new_len = self.byte_to_token_idx.len() - n_bytes;
-
-        self.byte_to_token_idx.truncate(new_len);
-        self.bytes.truncate(new_len);
-        self.lexer_stack.truncate(new_len + 1);
+        self.byte_to_token_idx.truncate(cp.byte_len);
+        self.bytes.truncate(cp.byte_len);
+        self.lexer_stack.truncate(cp.byte_len + 1);
 
         self.row_infos.truncate(self.num_rows());
-        self.token_idx = *self.byte_to_token_idx.last().unwrap_or(&0) as usize;
+        self.token_idx = cp.token_idx;
         self.last_force_bytes_len = usize::MAX;
         self.lexer_stack_top_eos = false;
         self.rows_valid_end = self.num_rows();
@@ -1034,6 +1052,27 @@ impl ParserState {
         self.assert_definitive();
 
         Ok(())
+    }
+
+    /// Byte-count rollback backing the deprecated public [`Parser::rollback`].
+    /// Restores `token_idx` to the last kept byte's index (or 0).
+    fn rollback_n_bytes(&mut self, n_bytes: usize) -> Result<()> {
+        ensure!(
+            n_bytes <= self.byte_to_token_idx.len(),
+            "rollback: too many bytes {} > {}",
+            n_bytes,
+            self.byte_to_token_idx.len()
+        );
+        let new_len = self.byte_to_token_idx.len() - n_bytes;
+        let token_idx = if new_len == 0 {
+            0
+        } else {
+            self.byte_to_token_idx[new_len - 1] as usize
+        };
+        self.rollback_to(ParserCheckpoint {
+            byte_len: new_len,
+            token_idx,
+        })
     }
 
     pub fn validate_tokens(&mut self, tokens: &[TokenId]) -> usize {
@@ -2843,9 +2882,32 @@ impl Parser {
         r
     }
 
+    pub(crate) fn checkpoint(&self) -> ParserCheckpoint {
+        self.state.checkpoint()
+    }
+
+    pub(crate) fn rollback_to(&mut self, cp: ParserCheckpoint) -> Result<()> {
+        self.state.lexer_spec().check_rollback()?;
+        self.with_shared(|state| state.rollback_to(cp))
+    }
+
+    /// Restore to the initial (pre-generation) state; used by [`crate::TokenParser::reset`].
+    pub(crate) fn rollback_to_start(&mut self) -> Result<()> {
+        self.state.lexer_spec().check_rollback()?;
+        self.with_shared(|state| {
+            state.rollback_to(ParserCheckpoint {
+                byte_len: 0,
+                token_idx: 0,
+            })
+        })
+    }
+
+    #[deprecated(
+        note = "byte counts do not identify a complete token checkpoint; use TokenParser::rollback"
+    )]
     pub fn rollback(&mut self, n_bytes: usize) -> Result<()> {
         self.state.lexer_spec().check_rollback()?;
-        self.with_shared(|state| state.rollback(n_bytes))
+        self.with_shared(|state| state.rollback_n_bytes(n_bytes))
     }
 
     /// Returns how many tokens can be applied.

--- a/parser/src/tokenparser.rs
+++ b/parser/src/tokenparser.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, hint::black_box, panic::AssertUnwindSafe, sync::Arc, tim
 
 use crate::{
     api::{GrammarInit, ParserLimits, StopReason},
-    earley::{BiasComputer, Parser, ParserError, ParserStats},
+    earley::{BiasComputer, Parser, ParserCheckpoint, ParserError, ParserStats},
     infoln, panic_utils, warn, Instant, Logger, ParserFactory,
 };
 use anyhow::{ensure, Result};
@@ -41,8 +41,24 @@ pub struct TokenParser {
     llm_tokens: Vec<TokenId>,
     llm_bytes: Vec<u8>,
 
+    // One rollback checkpoint per `llm_tokens` entry (recorded, not inferred —
+    // see `restore`).
+    checkpoints: Vec<TokenCheckpoint>,
+
+    // Number of immutable prompt/forced-prefix tokens; `rollback` may not cross
+    // below it (see `rollback`). Set by `process_prompt`.
+    prompt_token_floor: usize,
+
     grm_prefix: Vec<u8>,
     is_fresh: bool,
+}
+
+/// Per-LLM-token rollback checkpoint: the parser restore point plus the
+/// `llm_bytes` length, both captured after the token was processed.
+#[derive(Clone, Copy)]
+struct TokenCheckpoint {
+    parser: ParserCheckpoint,
+    llm_bytes_len: usize,
 }
 
 impl TokenParser {
@@ -115,6 +131,8 @@ impl TokenParser {
             eos_tokens,
             llm_tokens: Vec::new(),
             llm_bytes: Vec::new(),
+            checkpoints: Vec::new(),
+            prompt_token_floor: 0,
             grm_prefix: Vec::new(),
             max_tokens_total: max_tokens,
             last_bias_time: Duration::from_secs(0),
@@ -283,8 +301,41 @@ impl TokenParser {
             );
         }
 
+        // The prompt/grammar-prefix tokens were applied in bulk via
+        // apply_forced and are immutable under the speculative-rollback
+        // contract. They share the post-prefix parser position; record it for
+        // each so `checkpoints` stays aligned with `llm_tokens`, and mark the
+        // floor that `rollback` may not cross.
+        let prefix_cp = TokenCheckpoint {
+            parser: self.parser.checkpoint(),
+            llm_bytes_len: self.llm_bytes.len(),
+        };
+        self.checkpoints = vec![prefix_cp; self.llm_tokens.len()];
+        self.prompt_token_floor = self.llm_tokens.len();
+
         infoln!(self, "res_prompt: {}", trie.tokens_dbg(&res_prompt));
         res_prompt
+    }
+
+    /// Record the checkpoint for the just-processed token, one per `llm_tokens`
+    /// entry. A consume adds exactly one token (assert); a backtrack removes
+    /// some. Either way, align the length and set the tail to the current state.
+    fn record_checkpoint(&mut self) {
+        debug_assert!(
+            self.checkpoints.len() + 1 >= self.llm_tokens.len(),
+            "record_checkpoint: {} tokens added since last checkpoint",
+            self.llm_tokens.len() - self.checkpoints.len()
+        );
+        let cp = TokenCheckpoint {
+            parser: self.parser.checkpoint(),
+            llm_bytes_len: self.llm_bytes.len(),
+        };
+        self.checkpoints.truncate(self.llm_tokens.len());
+        if self.checkpoints.len() < self.llm_tokens.len() {
+            self.checkpoints.push(cp);
+        } else if let Some(last) = self.checkpoints.last_mut() {
+            *last = cp;
+        }
     }
 
     pub fn augment_err(&self, e: impl Display) -> String {
@@ -367,10 +418,25 @@ impl TokenParser {
         self.validate_tokens_raw(&[token]).map(|n| n > 0)
     }
 
+    /// Return generation to the start of the grammar, dropping all consumed
+    /// tokens including the prompt prefix. Does not clear captures, backtrack
+    /// flags, or stats. Unlike `rollback`, `reset` may cross the immutable
+    /// prompt prefix; it is a no-op on a fresh parser.
     pub fn reset(&mut self) -> Result<()> {
-        self.rollback(self.llm_tokens.len())
+        if !self.llm_tokens.is_empty() {
+            self.restore(0)?;
+        }
+        self.prompt_token_floor = 0;
+        Ok(())
     }
 
+    /// Roll back the last `n_tokens` generated tokens.
+    ///
+    /// Only generated (suffix) tokens may be undone; the prompt/forced prefix is
+    /// immutable. Rolling back into it returns an error without mutating state.
+    /// (One consequence: if natural backtracking has healed across the prompt
+    /// boundary, `prompt_token_floor` can exceed the current token count and
+    /// rollback then refuses everything until `reset`.)
     pub fn rollback(&mut self, n_tokens: usize) -> Result<()> {
         if n_tokens == 0 {
             return Ok(());
@@ -383,40 +449,58 @@ impl TokenParser {
             self.llm_tokens.len()
         );
 
+        let new_len = self.llm_tokens.len() - n_tokens;
+        // Failure-atomic prefix guard: reject before any mutation.
+        ensure!(
+            new_len >= self.prompt_token_floor,
+            "rollback into the immutable prompt prefix is not supported: \
+             target length {} < prompt floor {} (use reset() to start over)",
+            new_len,
+            self.prompt_token_floor
+        );
+
+        self.restore(new_len)
+    }
+
+    /// Shared restoration for `rollback`/`reset`: return to the recorded
+    /// checkpoint at `new_len` tokens (or the parser start when `new_len == 0`).
+    /// The caller is responsible for policy (e.g. the prefix floor).
+    ///
+    /// The target position is *recorded* per token rather than inferred, because
+    /// it can't be recovered from the current state: a `<[N]>` lexeme is stored
+    /// internally as `\xff[N]` (a different length than `token_len(N)`), forced
+    /// prefix bytes don't advance `token_idx`, and accepting-EOS tokens add no
+    /// bytes.
+    fn restore(&mut self, new_len: usize) -> Result<()> {
         if self.stop_reason.is_ok() {
-            // if we're stopped in "normal" way (e.g. end of grammar reached),
+            // if we're stopped in a "normal" way (end of grammar reached),
             // pretend we're not stopped
             self.stop_reason = StopReason::NotStopped;
         }
-
-        // this will fail in case we're in error state or not initialized
+        // fails if in error state or not initialized
         self.check_initialized("rollback")?;
-
         self.had_rollback = true;
 
-        let new_len = self.llm_tokens.len() - n_tokens;
-        let mut bytes_to_drop = 0;
-        for tok in &self.llm_tokens[new_len..] {
-            if self.eos_tokens.contains(tok) {
-                // doesn't count; we hope it's last though...
-                bytes_to_drop += 0;
-            } else {
-                bytes_to_drop += self.tok_trie().token_len(*tok);
-            }
-        }
-        ensure!(
-            bytes_to_drop <= self.llm_bytes.len(),
-            "rollback bytes: {} > {}",
-            bytes_to_drop,
-            self.llm_bytes.len()
+        debug_assert_eq!(
+            self.checkpoints.len(),
+            self.llm_tokens.len(),
+            "checkpoints out of sync with llm_tokens"
         );
 
-        self.parser.rollback(bytes_to_drop)?;
+        let dropped = self.llm_tokens.len() - new_len;
+        let llm_bytes_len = if new_len == 0 {
+            self.parser.rollback_to_start()?;
+            0
+        } else {
+            let cp = self.checkpoints[new_len - 1];
+            self.parser.rollback_to(cp.parser)?;
+            cp.llm_bytes_len
+        };
 
-        self.max_tokens_total = self.max_tokens_total.saturating_add(n_tokens);
+        self.max_tokens_total = self.max_tokens_total.saturating_add(dropped);
         self.llm_tokens.truncate(new_len);
-        self.llm_bytes
-            .truncate(self.llm_bytes.len() - bytes_to_drop);
+        self.llm_bytes.truncate(llm_bytes_len);
+        self.checkpoints.truncate(new_len);
         self.clear_caches();
 
         Ok(())
@@ -632,6 +716,9 @@ impl TokenParser {
                         // the non-backtracked bytes of backtracked token
                         self.parser.additional_backtrack(additional_backtrack_bytes);
                     }
+                    // Note: if healing crosses the prompt boundary this leaves
+                    // `prompt_token_floor > llm_tokens.len()`; rollback then
+                    // conservatively refuses until `reset` (see the field doc).
                     self.llm_tokens.truncate(token_ptr);
                     return Ok(backtrack_tokens);
                 }
@@ -831,6 +918,9 @@ impl TokenParser {
                 );
                 if accepting {
                     self.llm_tokens.push(token);
+                    // zero-byte token: nothing consumed, but keep checkpoints
+                    // aligned so a later rollback over it is a no-op.
+                    self.record_checkpoint();
                     return Ok(0);
                 }
             }
@@ -840,7 +930,10 @@ impl TokenParser {
         self.parser.log_row_infos("post-apply");
         match apply_res {
             Err(_) => Err(self.anyhow_error()),
-            Ok(n) => Ok(n),
+            Ok(n) => {
+                self.record_checkpoint();
+                Ok(n)
+            }
         }
     }
 

--- a/parser/tests/test_raw_parser.rs
+++ b/parser/tests/test_raw_parser.rs
@@ -287,6 +287,152 @@ fn test_lexer_inv_crash() {
 }
 
 #[test]
+fn test_rollback_forced_numeric_tokens() {
+    let trie = get_tok_env().tok_trie();
+    let token_ids = numeric_usable_token_ids(4);
+    let grammar = format!(
+        "start: sequence\nsequence[capture]: {}",
+        token_ids
+            .iter()
+            .map(|token_id| format!("<[{token_id}]>"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    let mut parser = make_parser(&grammar);
+    let mut expected_after_one_token = make_parser(&grammar);
+    let expected_initial_mask = expected_after_one_token.compute_mask().unwrap();
+    consume(&mut expected_after_one_token, token_ids[0]);
+    let expected_after_one_token_mask = expected_after_one_token.compute_mask().unwrap();
+
+    for token_id in &token_ids[..2] {
+        let mask = parser.compute_mask().unwrap();
+        assert!(mask.is_allowed(*token_id));
+        consume(&mut parser, *token_id);
+    }
+
+    parser.rollback(1).unwrap();
+
+    let mask = parser.compute_mask().unwrap();
+    assert_eq!(mask, expected_after_one_token_mask);
+
+    parser.rollback(1).unwrap();
+
+    let mask = parser.compute_mask().unwrap();
+    assert_eq!(mask, expected_initial_mask);
+
+    for token_id in &token_ids {
+        consume(&mut parser, *token_id);
+    }
+    assert!(parser.is_accepting());
+    assert_eq!(parser.get_capture("sequence"), Some(trie.decode(&token_ids).as_slice()));
+}
+
+// Pick `count` ordinary (non-special) token ids whose natural byte length is
+// shorter than their `\xff[N]` numeric encoding, so `<[N]>` exercises the
+// byte-length mismatch that rollback accounting must handle.
+fn numeric_usable_token_ids(count: usize) -> Vec<u32> {
+    let trie = get_tok_env().tok_trie();
+    let ids = (0..trie.vocab_size() as u32)
+        .filter(|&id| {
+            let numeric_encoding_len = id.to_string().len() + 3;
+            !trie.is_special_token(id) && trie.token(id).len() < numeric_encoding_len
+        })
+        .take(count)
+        .collect::<Vec<_>>();
+    assert_eq!(ids.len(), count);
+    ids
+}
+
+// Build a parser and run process_prompt with no prompt, so a leading forced
+// literal becomes the immutable prompt prefix.
+fn prompted(grammar: &str) -> TokenParser {
+    let mut p = PARSER_FACTORY
+        .create_parser(TopLevelGrammar::from_lark(grammar.to_string()))
+        .unwrap();
+    p.process_prompt(vec![]);
+    p
+}
+
+// rollback may not cross into the immutable prompt prefix. This is a policy
+// test, so the generated token is an ordinary letter (not a numeric `<[N]>`).
+#[test]
+fn test_rollback_into_forced_prefix_is_rejected() {
+    let mut parser = prompted(r#"start: "hello world foo bar baz" /[a-z]/"#);
+    let floor = parser.num_tokens();
+    assert!(floor >= 2, "expected a multi-token forced prefix, got {floor}");
+
+    let prefix_mask = parser.compute_mask().unwrap();
+    let trie = get_tok_env().tok_trie();
+    let letter = (0..trie.vocab_size() as u32)
+        .find(|&t| prefix_mask.is_allowed(t) && !trie.is_special_token(t))
+        .expect("a letter token must be allowed after the prefix");
+
+    consume(&mut parser, letter);
+    let snap = (
+        parser.num_tokens(),
+        parser.bytes_since(0).to_vec(),
+        parser.is_accepting(),
+        parser.compute_mask().unwrap(),
+    );
+
+    // Rolling back into the prefix hits the floor guard specifically and leaves
+    // observable state untouched (failure atomicity).
+    let err = parser.rollback(2).unwrap_err().to_string();
+    assert!(err.contains("immutable prompt prefix"), "unexpected error: {err}");
+    assert_eq!(parser.num_tokens(), snap.0);
+    assert_eq!(parser.bytes_since(0), snap.1.as_slice());
+    assert_eq!(parser.is_accepting(), snap.2);
+    assert_eq!(parser.compute_mask().unwrap(), snap.3);
+
+    // Target == floor is the valid boundary: back to the post-prefix state.
+    parser.rollback(1).unwrap();
+    assert_eq!(parser.num_tokens(), floor);
+    assert_eq!(parser.compute_mask().unwrap(), prefix_mask);
+}
+
+// reset crosses the prompt prefix (unlike rollback) and returns to grammar start.
+#[test]
+fn test_reset_after_prompt_returns_to_start() {
+    let grammar = r#"start: "hello world" /[a-z]/"#;
+
+    let mut fresh = make_parser(grammar); // make_parser calls start_without_prompt
+    let start_mask = fresh.compute_mask().unwrap();
+
+    let mut parser = prompted(grammar);
+    assert!(parser.num_tokens() >= 1);
+    let trie = get_tok_env().tok_trie();
+    let letter = (0..trie.vocab_size() as u32)
+        .find(|&t| parser.compute_mask().unwrap().is_allowed(t) && !trie.is_special_token(t))
+        .unwrap();
+    consume(&mut parser, letter);
+
+    parser.reset().unwrap();
+    assert_eq!(parser.num_tokens(), 0);
+    assert_eq!(parser.compute_mask().unwrap(), start_mask);
+}
+
+// An EOS id used as a numeric token `<[EOS]>` has real bytes, so rollback must
+// not treat it as a zero-byte EOS sentinel.
+#[test]
+fn test_rollback_eos_id_used_as_numeric_token() {
+    let eos = get_tok_env().tok_trie().eos_token();
+    let next = numeric_usable_token_ids(1)[0];
+    let grammar = format!("start: <[{eos}]> <[{next}]>");
+
+    let expected_mask = make_parser(&grammar).compute_mask().unwrap();
+
+    let mut parser = make_parser(&grammar);
+    assert!(parser.compute_mask().unwrap().is_allowed(eos));
+    consume(&mut parser, eos);
+    parser.rollback(1).unwrap();
+    assert_eq!(parser.compute_mask().unwrap(), expected_mask);
+
+    consume(&mut parser, eos);
+    consume(&mut parser, next);
+    assert!(parser.is_accepting());
+}
+
+#[test]
 fn test_stop_when_try_consume_fails() {
     let lark = r#"
         start: "blah"* "stop"


### PR DESCRIPTION
Record parser checkpoints per consumed token instead of inferring rollback boundaries from tokenizer byte lengths. This handles <[N]> encodings and EOS tokens correctly, rejects rollback into the immutable prompt prefix, and preserves the legacy byte-based Parser::rollback API as deprecated.