### PR TITLE
[Feature] Add container_whitespace to bound whitespace around {}/[]

### DIFF
--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -26,6 +26,7 @@ pub struct JsonCompileOptions {
     pub key_separator: String,
     pub whitespace_flexible: bool,
     pub whitespace_pattern: Option<String>,
+    pub container_whitespace: Option<String>,
     pub coerce_one_of: bool,
     pub lenient: bool,
     /// Allowed escape letters after '\' when quoting JSON strings.
@@ -64,6 +65,7 @@ struct Compiler {
     string_cache: Option<NodeRef>,
     item_separator_cache: Option<NodeRef>,
     key_separator_cache: Option<NodeRef>,
+    container_whitespace_cache: Option<NodeRef>,
 }
 
 macro_rules! cache {
@@ -82,6 +84,7 @@ impl Default for JsonCompileOptions {
             key_separator: ":".to_string(),
             whitespace_pattern: None,
             whitespace_flexible: true,
+            container_whitespace: None,
             coerce_one_of: false,
             lenient: false,
             json_allowed_escapes: None,
@@ -145,6 +148,7 @@ impl Compiler {
             string_cache: None,
             item_separator_cache: None,
             key_separator_cache: None,
+            container_whitespace_cache: None,
             pattern_cache: PatternPropertyCache::default(),
         }
     }
@@ -357,6 +361,21 @@ impl Compiler {
         let rx = self.builder.regex.regex(&self.options.key_separator)?;
         let node = self.builder.lexeme(rx);
         self.key_separator_cache = Some(node);
+        Ok(node)
+    }
+
+    fn container_whitespace(&mut self) -> Result<NodeRef> {
+        if let Some(node) = self.container_whitespace_cache {
+            return Ok(node);
+        }
+        let node = match &self.options.container_whitespace {
+            Some(pattern) => {
+                let rx = self.builder.regex.regex(pattern)?;
+                self.builder.lexeme(rx)
+            }
+            None => self.builder.string(""),
+        };
+        self.container_whitespace_cache = Some(node);
         Ok(node)
     }
 
@@ -612,9 +631,13 @@ impl Compiler {
 
     fn object_fields(&mut self, items: &[(NodeRef, bool)]) -> Result<NodeRef> {
         let opener = self.builder.string("{");
+        let ws_open = self.container_whitespace()?;
         let inner = self.ordered_sequence(items, false, &mut HashMap::default())?;
+        let ws_close = self.container_whitespace()?;
         let closer = self.builder.string("}");
-        Ok(self.builder.join(&[opener, inner, closer]))
+        Ok(self
+            .builder
+            .join(&[opener, ws_open, inner, ws_close, closer]))
     }
 
     #[allow(clippy::type_complexity)]
@@ -902,8 +925,12 @@ impl Compiler {
             }
         }
 
-        let mut grammars: Vec<NodeRef> = vec![self.builder.string("[")];
+        let opener = self.builder.string("[");
+        let closer = self.builder.string("]");
         let comma = self.item_separator()?;
+
+        let ws_open = self.container_whitespace()?;
+        let mut grammars: Vec<NodeRef> = vec![opener, ws_open];
 
         if !required_items.is_empty() {
             grammars.push(required_items[0]);
@@ -934,7 +961,9 @@ impl Compiler {
             }
         }
 
-        grammars.push(self.builder.string("]"));
+        let ws_close = self.container_whitespace()?;
+        grammars.push(ws_close);
+        grammars.push(closer);
         Ok(self.builder.join(&grammars))
     }
 }

--- a/parser/tests/test_json_x_guidance.rs
+++ b/parser/tests/test_json_x_guidance.rs
@@ -502,3 +502,36 @@ fn test_no_container_whitespace_with_object_schema(
     let lark = format!("start: %json {object_schema}");
     lark_str_test(&lark, should_succeed, input, true);
 }
+
+#[rstest]
+// Ok
+#[case::after_open_max(8, false, true)]
+#[case::after_open_over(9, false, true)] // Note over the bound, allowed by whitespace_flexible
+#[case::before_close_max(8, true, true)]
+#[case::before_close_over(9, true, true)] // Note over the bound, allowed by whitespace_flexible
+fn test_container_whitespace_with_flexible_whitespace(
+    #[case] spaces: usize,
+    #[case] before_close: bool,
+    #[case] should_succeed: bool,
+) {
+    let object_schema = json!({
+        "type": "object",
+        "properties": { "a": { "type": "integer" }, "b": { "type": "integer" } },
+        "required": ["a", "b"],
+        "additionalProperties": false,
+        "x-guidance": {
+            "whitespace_flexible": true,
+            "container_whitespace": r"\s{0,8}",
+            "key_separator": r"\s{0,8}:\s{0,8}",
+            "item_separator": r"\s{0,8},\s{0,8}",
+        }
+    });
+    let pad = " ".repeat(spaces);
+    let input = if before_close {
+        format!("{{\"a\": 1, \"b\": 2{pad}}}")
+    } else {
+        format!("{{{pad}\"a\": 1, \"b\": 2}}")
+    };
+    let lark = format!("start: %json {object_schema}");
+    lark_str_test(&lark, should_succeed, &input, true);
+}

--- a/parser/tests/test_json_x_guidance.rs
+++ b/parser/tests/test_json_x_guidance.rs
@@ -364,3 +364,141 @@ fn whitespace_flexible_many_formats(
     );
     lark_str_test(&lark, true, &target_str, true);
 }
+
+#[rstest]
+#[case::compact(r#"{"a":1,"b":2}"#, true)]
+#[case::spaced_braces(r#"{ "a": 1, "b": 2 }"#, true)]
+#[case::two_spaces_at_braces(r#"{  "a": 1, "b": 2  }"#, true)]
+#[case::pretty_print("{\n  \"a\": 1,\n  \"b\": 2\n}", true)]
+fn test_container_whitespace_with_object_schema(#[case] input: &str, #[case] should_succeed: bool) {
+    let object_schema = json!({
+        "type": "object",
+        "properties": { "a": { "type": "integer" }, "b": { "type": "integer" } },
+        "required": ["a", "b"],
+        "additionalProperties": false,
+        "x-guidance": {
+            "whitespace_flexible": false,
+            "container_whitespace": r"\s{0,8}",
+            "key_separator": r"\s{0,8}:\s{0,8}",
+            "item_separator": r"\s{0,8},\s{0,8}",
+        }
+    });
+    let lark = format!("start: %json {object_schema}");
+    lark_str_test(&lark, should_succeed, input, true);
+}
+
+#[rstest]
+#[case::compact(r#"[1,2]"#, true)]
+#[case::spaced_brackets(r#"[ 1, 2 ]"#, true)]
+#[case::two_spaces(r#"[  1, 2  ]"#, true)]
+#[case::pretty_print("[\n  1,\n  2\n]", true)]
+#[case::empty(r#"[]"#, true)]
+#[case::empty_spaced(r#"[ ]"#, true)]
+fn test_container_whitespace_with_array_schema(#[case] input: &str, #[case] should_succeed: bool) {
+    let array_schema = json!({
+        "type": "array",
+        "items": { "type": "integer" },
+        "x-guidance": {
+            "whitespace_flexible": false,
+            "container_whitespace": r"\s{0,8}",
+            "item_separator": r"\s{0,8},\s{0,8}",
+        }
+    });
+    let lark = format!("start: %json {array_schema}");
+    lark_str_test(&lark, should_succeed, input, true);
+}
+
+#[rstest]
+#[case::empty(0, true)]
+#[case::two_spaces(2, true)]
+#[case::max(16, true)]
+#[case::over_max(17, false)]
+fn test_container_whitespace_empty_object(#[case] spaces: usize, #[case] should_succeed: bool) {
+    let object_schema = json!({
+        "type": "object",
+        "properties": { "a": { "type": "integer" }, "b": { "type": "integer" } },
+        "required": [],
+        "additionalProperties": false,
+        "x-guidance": {
+            "whitespace_flexible": false,
+            "container_whitespace": r"\s{0,8}",
+            "key_separator": r"\s{0,8}:\s{0,8}",
+            "item_separator": r"\s{0,8},\s{0,8}",
+        }
+    });
+    let lark = format!("start: %json {object_schema}");
+    let input = format!("{{{}}}", " ".repeat(spaces));
+    lark_str_test(&lark, should_succeed, &input, true);
+}
+
+#[rstest]
+#[case::empty(r#"{}"#, true)]
+#[case::spaced(r#"{  }"#, true)]
+fn test_container_whitespace_no_property_object(#[case] input: &str, #[case] should_succeed: bool) {
+    let object_schema = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "x-guidance": {
+            "whitespace_flexible": false,
+            "container_whitespace": r"\s{0,8}",
+            "key_separator": r"\s{0,8}:\s{0,8}",
+            "item_separator": r"\s{0,8},\s{0,8}",
+        }
+    });
+    let lark = format!("start: %json {object_schema}");
+    lark_str_test(&lark, should_succeed, input, true);
+}
+
+#[rstest]
+#[case::after_open_max(8, false, true)]
+#[case::after_open_over(9, false, false)]
+#[case::before_close_max(8, true, true)]
+#[case::before_close_over(9, true, false)]
+fn test_container_whitespace_bound(
+    #[case] spaces: usize,
+    #[case] before_close: bool,
+    #[case] should_succeed: bool,
+) {
+    let object_schema = json!({
+        "type": "object",
+        "properties": { "a": { "type": "integer" }, "b": { "type": "integer" } },
+        "required": ["a", "b"],
+        "additionalProperties": false,
+        "x-guidance": {
+            "whitespace_flexible": false,
+            "container_whitespace": r"\s{0,8}",
+            "key_separator": r"\s{0,8}:\s{0,8}",
+            "item_separator": r"\s{0,8},\s{0,8}",
+        }
+    });
+    let pad = " ".repeat(spaces);
+    let input = if before_close {
+        format!("{{\"a\": 1, \"b\": 2{pad}}}")
+    } else {
+        format!("{{{pad}\"a\": 1, \"b\": 2}}")
+    };
+    let lark = format!("start: %json {object_schema}");
+    lark_str_test(&lark, should_succeed, &input, true);
+}
+
+#[rstest]
+#[case::spaced_braces(r#"{ "a": 1, "b": 2 }"#, false)]
+#[case::compact(r#"{"a": 1, "b": 2}"#, true)]
+fn test_no_container_whitespace_with_object_schema(
+    #[case] input: &str,
+    #[case] should_succeed: bool,
+) {
+    let object_schema = json!({
+        "type": "object",
+        "properties": { "a": { "type": "integer" }, "b": { "type": "integer" } },
+        "required": ["a", "b"],
+        "additionalProperties": false,
+        "x-guidance": {
+            "whitespace_flexible": false,
+            "key_separator": r"\s{0,8}:\s{0,8}",
+            "item_separator": r"\s{0,8},\s{0,8}",
+        }
+    });
+    let lark = format!("start: %json {object_schema}");
+    lark_str_test(&lark, should_succeed, input, true);
+}

--- a/python/llguidance/_lib.pyi
+++ b/python/llguidance/_lib.pyi
@@ -453,6 +453,7 @@ class JsonCompiler:
         whitespace_flexible: bool = False,
         coerce_one_of: bool = False,
         whitespace_pattern: Optional[str] = None,
+        container_whitespace: Optional[str] = None,
     ) -> "JsonCompiler":
         """
         Create a new JSON compiler.

--- a/python_ext/src/py.rs
+++ b/python_ext/src/py.rs
@@ -382,6 +382,7 @@ struct JsonCompiler {
     key_separator: String,
     whitespace_flexible: bool,
     whitespace_pattern: Option<String>,
+    container_whitespace: Option<String>,
     coerce_one_of: bool,
     json_allowed_escapes: Option<String>,
 }
@@ -389,12 +390,13 @@ struct JsonCompiler {
 #[pymethods]
 impl JsonCompiler {
     #[new]
-    #[pyo3(signature = (separators = None, whitespace_flexible = false, coerce_one_of = false, whitespace_pattern = None, json_allowed_escapes = None))]
+    #[pyo3(signature = (separators = None, whitespace_flexible = false, coerce_one_of = false, whitespace_pattern = None, container_whitespace = None, json_allowed_escapes = None))]
     fn py_new(
         separators: Option<(String, String)>,
         whitespace_flexible: bool,
         coerce_one_of: bool,
         whitespace_pattern: Option<String>,
+        container_whitespace: Option<String>,
         json_allowed_escapes: Option<String>,
     ) -> Self {
         let (item_separator, key_separator) = separators.unwrap_or_else(|| {
@@ -410,6 +412,7 @@ impl JsonCompiler {
             whitespace_flexible,
             coerce_one_of,
             whitespace_pattern,
+            container_whitespace,
             json_allowed_escapes,
         }
     }
@@ -422,6 +425,7 @@ impl JsonCompiler {
             whitespace_flexible: self.whitespace_flexible,
             coerce_one_of: self.coerce_one_of,
             whitespace_pattern: self.whitespace_pattern.clone(),
+            container_whitespace: self.container_whitespace.clone(),
             lenient: false,
             json_allowed_escapes: self.json_allowed_escapes.clone(),
             retriever: None,


### PR DESCRIPTION
JSON structural whitespace directly after '{'/'[' and before '}'/']' is only produced by the repeatable lexer skip, so it can only be either 0 (whitespace_flexible=false) or unbounded (any skip pattern, since the skip lexeme repeats). That makes bounded-but-nonzero forms such as { "a": 1 } or [ 1, 2 ] impossible without risking runaway whitespace. The separators (item_separator/key_separator) already provide bounded, once-matched whitespace, but only around ':' and ','.

Add JsonCompileOptions.container_whitespace: Option<String>. When set, a once-matched whitespace lexeme (built like the separators) is inserted after '{'/'[' and before '}'/']', so a pattern such as [\x20\x0A\x0D\x09]{0,8} is enforced there. Defaults to None; settable via x-guidance.

Refs: guidance-ai/llguidance#247