### PR TITLE
Add CI support for Windows ARM64 Python wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,8 +144,13 @@ jobs:
         platform:
           - runner: windows-latest
             target: x64
+            python-architecture: x64
           - runner: windows-latest
             target: x86
+            python-architecture: x86
+          - runner: windows-11-arm
+            target: aarch64
+            python-architecture: arm64
         python-version: ['3.12', '3.14t']
     steps:
       - uses: actions/checkout@v6
@@ -153,7 +158,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.platform.target }}
+          architecture: ${{ matrix.platform.python-architecture }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1


### PR DESCRIPTION
Hi @hudson-ai, I'm from Microsoft and recently I'm working on improving Python ecosystem support for Windows on Arm.
So I adds CI support for Windows ARM64. Could you please help to review? Thanks.

**Platform and architecture improvements:**

* Added a new build matrix entry for Windows 11 ARM (`runner: windows-11-arm`, `target: aarch64`, `python-architecture: arm64`) to enable ARM64 wheel builds.
* Explicitly specified `python-architecture` for each Windows platform variant (`x64`, `x86`, `arm64`) to clarify and control which Python architecture is used in each build.
* Updated the `actions/setup-python` step to use the new `python-architecture` matrix variable instead of the previous `target`, ensuring the correct Python architecture is installed for each build.

**Pipeline Run Results**
https://github.com/chinazhangchao/llguidance/actions/runs/30439237592