### PR TITLE
Preserve exclusive bound names in schema errors

### DIFF
--- a/parser/src/json/numeric.rs
+++ b/parser/src/json/numeric.rs
@@ -510,20 +510,22 @@ pub fn check_number_bounds(num: &NumberSchema) -> Result<(), String> {
     let (minimum, exclusive_minimum) = num.get_minimum();
     let (maximum, exclusive_maximum) = num.get_maximum();
     if let (Some(min), Some(max)) = (minimum, maximum) {
+        let minimum_repr = if exclusive_minimum {
+            "exclusiveMinimum"
+        } else {
+            "minimum"
+        };
+        let maximum_repr = if exclusive_maximum {
+            "exclusiveMaximum"
+        } else {
+            "maximum"
+        };
         if min > max {
-            return Err(format!("minimum ({min}) is greater than maximum ({max})"));
+            return Err(format!(
+                "{minimum_repr} ({min}) is greater than {maximum_repr} ({max})"
+            ));
         }
         if min == max && (exclusive_minimum || exclusive_maximum) {
-            let minimum_repr = if exclusive_minimum {
-                "exclusiveMinimum"
-            } else {
-                "minimum"
-            };
-            let maximum_repr = if exclusive_maximum {
-                "exclusiveMaximum"
-            } else {
-                "maximum"
-            };
             return Err(format!(
                 "{minimum_repr} ({min}) is equal to {maximum_repr} ({max})"
             ));

--- a/parser/tests/test_json_primitives.rs
+++ b/parser/tests/test_json_primitives.rs
@@ -174,10 +174,8 @@ fn integer_limits_incompatible(
         min_type: 1,
         max_type: -1
     });
-    json_err_test(
-        schema,
-        "Unsatisfiable schema: minimum (1) is greater than maximum (-1)",
-    );
+    let expected = format!("Unsatisfiable schema: {min_type} (1) is greater than {max_type} (-1)");
+    json_err_test(schema, &expected);
 }
 
 #[rstest]
@@ -387,10 +385,9 @@ fn number_limits_incompatible(
         min_type: -0.1,
         max_type: -1.0
     });
-    json_err_test(
-        schema,
-        "Unsatisfiable schema: minimum (-0.1) is greater than maximum (-1)",
-    );
+    let expected =
+        format!("Unsatisfiable schema: {min_type} (-0.1) is greater than {max_type} (-1)");
+    json_err_test(schema, &expected);
 }
 
 #[rstest]


### PR DESCRIPTION
Fixes #207

## Summary

Unsatisfiable `integer` and `number` schemas currently report their bounds as `minimum` and `maximum`, even when the effective bounds came from `exclusiveMinimum` or `exclusiveMaximum`.

`check_number_bounds()` already knows whether each selected bound is exclusive, but the greater-than error path hard-codes the inclusive keyword names. This change derives the effective keyword names once and uses them in both the greater-than and equal-bound diagnostics.

The existing parameterized tests now verify all inclusive/exclusive lower- and upper-bound combinations for both integer and number schemas.

This only changes diagnostic text; schema acceptance behavior remains unchanged.

## Testing

- `cargo test -p llguidance --test test_json_primitives`
- `cargo build --locked`
- Full debug and release `cargo nextest` suites
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check --no-default-features -p llguidance`

## Scope

This does not address the separate empty exclusive-integer interval behavior described in #206.

