### PR TITLE
Add single-match skip lexemes

### DIFF
--- a/docs/json_schema.md
+++ b/docs/json_schema.md
@@ -79,10 +79,11 @@ Following keys are available inside of it:
 - `item_separator`, defaults to `","` - a regex pattern for the separator between array items or object properties
 - `key_separator`, defaults to `":"` - a regex pattern for the separator between object keys and values
 - `whitespace_flexible`, defaults to `true`; set to `false` to enforce compact JSON representation
-- `whitespace_pattern`, optional string, overrides `whitespace_flexible`;
-  `whitespace_flexible: true` is equivalent to `whitespace_pattern: r"[\x20\x0A\x0D\x09]+"`.
-  The pattern describes one complete whitespace span, so repetition bounds such as
+- `whitespace_pattern`, optional string, overrides `whitespace_flexible`. The pattern
+  describes one complete whitespace span, so repetition bounds such as
   `r"[\x20\x0A\x0D\x09]{1,8}"` are enforced. The span itself remains optional.
+  `whitespace_flexible: true` is equivalent to
+  `whitespace_pattern: r"[\x20\x0A\x0D\x09]+"`.
 - `coerce_one_of`, defaults to `false`; when set to `true`, the `"oneOf"` will be treated as `"anyOf"`
 - `json_allowed_escapes`, optional string, defaults to `"nrbtf\\\"u"`; controls which escape
   sequences are allowed after `\` in JSON strings. Each character in the string enables the

--- a/docs/json_schema.md
+++ b/docs/json_schema.md
@@ -79,9 +79,9 @@ Following keys are available inside of it:
 - `item_separator`, defaults to `","` - a regex pattern for the separator between array items or object properties
 - `key_separator`, defaults to `":"` - a regex pattern for the separator between object keys and values
 - `whitespace_flexible`, defaults to `true`; set to `false` to enforce compact JSON representation
-- `whitespace_pattern`, optional string, overrides `whitespace_flexible`. The pattern
-  describes one complete whitespace span, so repetition bounds such as
-  `r"[\x20\x0A\x0D\x09]{1,8}"` are enforced. The span itself remains optional.
+- `whitespace_pattern`, optional string, overrides `whitespace_flexible`. The regex
+  is matched at most once at each location where JSON whitespace is allowed, so upper
+  bounds such as `r"[\x20\x0A\x0D\x09]{1,8}"` are enforced.
   `whitespace_flexible: true` is equivalent to
   `whitespace_pattern: r"[\x20\x0A\x0D\x09]+"`.
 - `coerce_one_of`, defaults to `false`; when set to `true`, the `"oneOf"` will be treated as `"anyOf"`

--- a/docs/json_schema.md
+++ b/docs/json_schema.md
@@ -80,7 +80,9 @@ Following keys are available inside of it:
 - `key_separator`, defaults to `":"` - a regex pattern for the separator between object keys and values
 - `whitespace_flexible`, defaults to `true`; set to `false` to enforce compact JSON representation
 - `whitespace_pattern`, optional string, overrides `whitespace_flexible`;
-  `whitespace_flexible: true` is equivalent to `whitespace_pattern: r"[\x20\x0A\x0D\x09]+"`
+  `whitespace_flexible: true` is equivalent to `whitespace_pattern: r"[\x20\x0A\x0D\x09]+"`.
+  The pattern describes one complete whitespace span, so repetition bounds such as
+  `r"[\x20\x0A\x0D\x09]{1,8}"` are enforced. The span itself remains optional.
 - `coerce_one_of`, defaults to `false`; when set to `true`, the `"oneOf"` will be treated as `"anyOf"`
 - `json_allowed_escapes`, optional string, defaults to `"nrbtf\\\"u"`; controls which escape
   sequences are allowed after `\` in JSON strings. Each character in the string enables the

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -323,7 +323,8 @@ MULT_NUM: %regex {
 
 Certain grammar options can be set by using `%llguidnace { ... }`,
 by passing it a JSON object with the options;
-see `LLGuidanceOptions` in [api.rs](../parser/src/api.rs#L36).
+most are defined by `LLGuidanceOptions` in [api.rs](../parser/src/api.rs),
+with syntax-specific options documented below.
 Example: `%llguidance { "no_forcing": true }`.
 It can be specified multiple times, with the options being merged.
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -321,9 +321,9 @@ MULT_NUM: %regex {
 
 ### Grammar options
 
-Certain grammar options can be set by using `%llguidnace { ... }`,
+Certain grammar options can be set by using `%llguidance { ... }`,
 by passing it a JSON object with the options;
-see `LLGuidanceOptions` in [api.rs](../parser/src/api.rs#L36).
+see `LLGuidanceOptions` in [api.rs](../parser/src/api.rs).
 Example: `%llguidance { "no_forcing": true }`.
 It can be specified multiple times, with the options being merged.
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -323,8 +323,7 @@ MULT_NUM: %regex {
 
 Certain grammar options can be set by using `%llguidnace { ... }`,
 by passing it a JSON object with the options;
-most are defined by `LLGuidanceOptions` in [api.rs](../parser/src/api.rs),
-with syntax-specific options documented below.
+see `LLGuidanceOptions` in [api.rs](../parser/src/api.rs#L36).
 Example: `%llguidance { "no_forcing": true }`.
 It can be specified multiple times, with the options being merged.
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -328,11 +328,11 @@ Example: `%llguidance { "no_forcing": true }`.
 It can be specified multiple times, with the options being merged.
 
 By default, a `%ignore` regex can be matched repeatedly at the same grammar
-position. Set `"skip_repetition": "once"` to make the regex describe the
-entire skipped span, which allows bounds in the regex to be enforced:
+position. Set `"ignore_once": true` to make the regex describe the entire
+skipped span, which allows bounds in the regex to be enforced:
 
 ```lark
-%llguidance { "skip_repetition": "once" }
+%llguidance { "ignore_once": true }
 %ignore /[ \t]{1,8}/
 start: "A" "!"
 ```

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -327,6 +327,16 @@ see `LLGuidanceOptions` in [api.rs](../parser/src/api.rs#L36).
 Example: `%llguidance { "no_forcing": true }`.
 It can be specified multiple times, with the options being merged.
 
+By default, a `%ignore` regex can be matched repeatedly at the same grammar
+position. Set `"skip_repetition": "once"` to make the regex describe the
+entire skipped span, which allows bounds in the regex to be enforced:
+
+```lark
+%llguidance { "skip_repetition": "once" }
+%ignore /[ \t]{1,8}/
+start: "A" "!"
+```
+
 You can also start the grammar file with `%llguidance {}` to indicate
 that llguidance should be used to process the grammar.
 

--- a/parser/src/api.rs
+++ b/parser/src/api.rs
@@ -39,6 +39,29 @@ pub enum SkipRepetition {
     Once,
 }
 
+/// The regex and repetition behavior of a compiled skip lexeme.
+#[derive(Debug, Clone)]
+pub struct SkipSpec {
+    /// Regex matched between grammar lexemes.
+    pub regex: RegexAst,
+    /// Whether the regex can be matched repeatedly at one grammar position.
+    pub repetition: SkipRepetition,
+}
+
+impl SkipSpec {
+    pub fn new(regex: RegexAst, repetition: SkipRepetition) -> Self {
+        Self { regex, repetition }
+    }
+
+    pub fn unbounded(regex: RegexAst) -> Self {
+        Self::new(regex, SkipRepetition::Unbounded)
+    }
+
+    pub fn once(regex: RegexAst) -> Self {
+        Self::new(regex, SkipRepetition::Once)
+    }
+}
+
 /// In lark syntax, this can be specified as JSON object after '%llguidance' declaration in the grammar.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -63,11 +86,6 @@ pub struct LLGuidanceOptions {
     /// including nested sub-grammars.
     #[serde(default)]
     pub allow_initial_skip: bool,
-
-    /// Controls whether the skip regex may be matched repeatedly at one grammar position.
-    /// With `once`, the regex describes the entire skipped span.
-    #[serde(default)]
-    pub skip_repetition: SkipRepetition,
 }
 
 impl LLGuidanceOptions {
@@ -80,9 +98,6 @@ impl LLGuidanceOptions {
         }
         if other.allow_initial_skip {
             self.allow_initial_skip = true;
-        }
-        if other.skip_repetition == SkipRepetition::Once {
-            self.skip_repetition = SkipRepetition::Once;
         }
     }
 }

--- a/parser/src/api.rs
+++ b/parser/src/api.rs
@@ -64,7 +64,6 @@ impl SkipSpec {
 
 /// In lark syntax, this can be specified as JSON object after '%llguidance' declaration in the grammar.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[non_exhaustive]
 pub struct LLGuidanceOptions {
     /// Normally, when a sequence of bytes is forced by grammar, it is tokenized
     /// canonically and forced as tokens.

--- a/parser/src/api.rs
+++ b/parser/src/api.rs
@@ -31,8 +31,17 @@ pub enum GrammarInit {
 /// cbindgen:ignore
 pub const DEFAULT_CONTEXTUAL: bool = true;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkipRepetition {
+    #[default]
+    Unbounded,
+    Once,
+}
+
 /// In lark syntax, this can be specified as JSON object after '%llguidance' declaration in the grammar.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct LLGuidanceOptions {
     /// Normally, when a sequence of bytes is forced by grammar, it is tokenized
     /// canonically and forced as tokens.
@@ -54,6 +63,11 @@ pub struct LLGuidanceOptions {
     /// including nested sub-grammars.
     #[serde(default)]
     pub allow_initial_skip: bool,
+
+    /// Controls whether the skip regex may be matched repeatedly at one grammar position.
+    /// With `once`, the regex describes the entire skipped span.
+    #[serde(default)]
+    pub skip_repetition: SkipRepetition,
 }
 
 impl LLGuidanceOptions {
@@ -66,6 +80,9 @@ impl LLGuidanceOptions {
         }
         if other.allow_initial_skip {
             self.allow_initial_skip = true;
+        }
+        if other.skip_repetition == SkipRepetition::Once {
+            self.skip_repetition = SkipRepetition::Once;
         }
     }
 }

--- a/parser/src/earley/lexerspec.rs
+++ b/parser/src/earley/lexerspec.rs
@@ -4,7 +4,7 @@ use std::{fmt::Debug, hash::Hash, ops::RangeInclusive};
 use toktrie::{bytes::limit_bytes, SimpleVob, TokTrie, TokenId};
 
 use crate::{
-    api::{ParserLimits, SkipRepetition},
+    api::{ParserLimits, SkipRepetition, SkipSpec},
     id32_type,
 };
 
@@ -188,11 +188,11 @@ impl LexerSpec {
             .has_simply_forced_bytes(lex_spec.compiled_rx, bytes)
     }
 
-    pub fn setup_lexeme_class(
-        &mut self,
-        skip: RegexAst,
-        skip_repetition: SkipRepetition,
-    ) -> Result<LexemeClass> {
+    pub fn setup_lexeme_class(&mut self, skip: SkipSpec) -> Result<LexemeClass> {
+        let SkipSpec {
+            regex: skip,
+            repetition: skip_repetition,
+        } = skip;
         let skip_node = self.regex_builder.mk(&skip)?; // validate first
 
         if !self.has_max_tokens && !self.has_temperature {

--- a/parser/src/earley/lexerspec.rs
+++ b/parser/src/earley/lexerspec.rs
@@ -188,7 +188,11 @@ impl LexerSpec {
             .has_simply_forced_bytes(lex_spec.compiled_rx, bytes)
     }
 
-    pub fn setup_lexeme_class(&mut self, skip: SkipSpec) -> Result<LexemeClass> {
+    pub fn setup_lexeme_class(&mut self, skip: RegexAst) -> Result<LexemeClass> {
+        self.setup_lexeme_class_with_skip(SkipSpec::unbounded(skip))
+    }
+
+    pub fn setup_lexeme_class_with_skip(&mut self, skip: SkipSpec) -> Result<LexemeClass> {
         let SkipSpec {
             regex: skip,
             repetition: skip_repetition,

--- a/parser/src/earley/lexerspec.rs
+++ b/parser/src/earley/lexerspec.rs
@@ -3,7 +3,10 @@ use derivre::{raw::ExprSet, ExprRef, HashMap, JsonQuoteOptions, RegexAst, RegexB
 use std::{fmt::Debug, hash::Hash, ops::RangeInclusive};
 use toktrie::{bytes::limit_bytes, SimpleVob, TokTrie, TokenId};
 
-use crate::{api::ParserLimits, id32_type};
+use crate::{
+    api::{ParserLimits, SkipRepetition},
+    id32_type,
+};
 
 use super::{
     lexer::MatchingLexemesIdx,
@@ -18,7 +21,7 @@ pub struct LexerSpec {
     pub allow_initial_skip: bool,
     pub num_extra_lexemes: usize,
     pub skip_by_class: Vec<LexemeIdx>,
-    class_by_skip: HashMap<ExprRef, LexemeClass>,
+    class_by_skip: HashMap<(ExprRef, SkipRepetition), LexemeClass>,
     pub current_class: LexemeClass,
     // regex for \xFF \[ [0-9]+ \]
     pub special_token_rx: Option<ExprRef>,
@@ -57,6 +60,7 @@ pub struct LexemeSpec {
     pub(crate) is_extra: bool,
     pub(crate) is_suffix: bool,
     pub(crate) is_skip: bool,
+    pub(crate) skip_repetition: SkipRepetition,
     json_options: Option<JsonQuoteOptions>,
     pub(crate) token_ranges: Vec<RangeInclusive<TokenId>>,
 }
@@ -184,11 +188,15 @@ impl LexerSpec {
             .has_simply_forced_bytes(lex_spec.compiled_rx, bytes)
     }
 
-    pub fn setup_lexeme_class(&mut self, skip: RegexAst) -> Result<LexemeClass> {
+    pub fn setup_lexeme_class(
+        &mut self,
+        skip: RegexAst,
+        skip_repetition: SkipRepetition,
+    ) -> Result<LexemeClass> {
         let skip_node = self.regex_builder.mk(&skip)?; // validate first
 
         if !self.has_max_tokens && !self.has_temperature {
-            if let Some(&cls) = self.class_by_skip.get(&skip_node) {
+            if let Some(&cls) = self.class_by_skip.get(&(skip_node, skip_repetition)) {
                 // re-use existing
                 self.current_class = cls;
                 return Ok(cls);
@@ -196,13 +204,15 @@ impl LexerSpec {
         }
 
         self.current_class = LexemeClass::new(self.skip_by_class.len());
-        self.class_by_skip.insert(skip_node, self.current_class);
+        self.class_by_skip
+            .insert((skip_node, skip_repetition), self.current_class);
         self.skip_by_class.push(LexemeIdx(0)); // avoid assert in empty_spec()
         let idx = self
             .add_lexeme_spec(LexemeSpec {
                 name: format!("SKIP{}", self.current_class.as_usize()),
                 rx: skip,
                 is_skip: true,
+                skip_repetition,
                 ..self.empty_spec()
             })
             .expect("already validated");
@@ -326,6 +336,8 @@ impl LexerSpec {
                 && lex.max_tokens == spec.max_tokens
                 && lex.token_ranges == spec.token_ranges
                 && lex.is_extra == spec.is_extra
+                && lex.is_skip == spec.is_skip
+                && lex.skip_repetition == spec.skip_repetition
         }) {
             return Ok(LexemeIdx::new(idx));
         }
@@ -355,6 +367,7 @@ impl LexerSpec {
             contextual: false,
             ends_at_eos: false,
             is_skip: false,
+            skip_repetition: SkipRepetition::Unbounded,
             is_suffix: false,
             is_extra: false,
             json_options: None,

--- a/parser/src/earley/parser.rs
+++ b/parser/src/earley/parser.rs
@@ -1773,7 +1773,8 @@ impl ParserState {
                 .just_add_idx(self.scratch.items[i], i, "skip_lexeme");
         }
 
-        let (grammar_id, max_token_ptr) = self.maybe_pop_grammar_stack(lexeme.idx);
+        let (mut grammar_id, max_token_ptr) = self.maybe_pop_grammar_stack(lexeme.idx);
+        let hit_max_tokens = max_token_ptr.is_some();
 
         // no process_agenda() in the normal case
 
@@ -1782,6 +1783,8 @@ impl ParserState {
             self.process_max_tokens(ptr, lexeme);
             // process_agenda() will recompute push_allowed_lexemes etc
             lex_start = None;
+            grammar_id =
+                self.scratch.grammar_stack[self.scratch.push_grm_top.as_usize()].grammar_id;
         } else if skip_repetition == SkipRepetition::Once {
             let skip_id = self.lexer_spec().skip_id(grammar_id);
             let mut possible = self
@@ -1793,7 +1796,8 @@ impl ParserState {
             lex_start = Some(self.shared_box.lexer_mut().start_state(&possible));
         }
 
-        let allow_skip = skip_repetition == SkipRepetition::Unbounded;
+        // A max-token pop moves to the parent grammar, whose skip has not been consumed.
+        let allow_skip = hit_max_tokens || skip_repetition == SkipRepetition::Unbounded;
         let push_res = self.just_push_row(grammar_id, lex_start, allow_skip);
         assert!(push_res);
 

--- a/parser/src/earley/parser.rs
+++ b/parser/src/earley/parser.rs
@@ -23,7 +23,7 @@ use toktrie::{
 };
 
 use crate::{
-    api::{ParserLimits, StopReason},
+    api::{ParserLimits, SkipRepetition, StopReason},
     earley::{lexer::Lexer, lexerspec::LexemeClass},
     id32_type,
 };
@@ -1754,7 +1754,7 @@ impl ParserState {
     }
 
     // this just copies current row
-    fn scan_skip_lexeme(&mut self, lexeme: &Lexeme) -> bool {
+    fn scan_skip_lexeme(&mut self, lexeme: &Lexeme, skip_repetition: SkipRepetition) -> bool {
         let src = self.curr_row().item_indices();
         let n = src.len();
         if n == 0 {
@@ -1782,9 +1782,19 @@ impl ParserState {
             self.process_max_tokens(ptr, lexeme);
             // process_agenda() will recompute push_allowed_lexemes etc
             lex_start = None;
+        } else if skip_repetition == SkipRepetition::Once {
+            let skip_id = self.lexer_spec().skip_id(grammar_id);
+            let mut possible = self
+                .shared_box
+                .lexer()
+                .possible_lexemes(lex_start.unwrap())
+                .clone();
+            possible.remove(skip_id);
+            lex_start = Some(self.shared_box.lexer_mut().start_state(&possible));
         }
 
-        let push_res = self.just_push_row(grammar_id, lex_start);
+        let allow_skip = skip_repetition == SkipRepetition::Unbounded;
+        let push_res = self.just_push_row(grammar_id, lex_start, allow_skip);
         assert!(push_res);
 
         true
@@ -1803,10 +1813,11 @@ impl ParserState {
         let set = self.shared_box.lexer().lexemes_from_idx(lexeme.idx);
 
         let lex_spec = self.lexer_spec();
-        for lx in set.as_slice() {
-            if lex_spec.lexeme_spec(*lx).is_skip {
-                return self.scan_skip_lexeme(lexeme);
-            }
+        if let Some(skip_repetition) = set.as_slice().iter().find_map(|lx| {
+            let spec = lex_spec.lexeme_spec(*lx);
+            spec.is_skip.then_some(spec.skip_repetition)
+        }) {
+            return self.scan_skip_lexeme(lexeme, skip_repetition);
         }
 
         let row_idx = self.num_rows() - 1;
@@ -2035,7 +2046,12 @@ impl ParserState {
     }
 
     #[inline(always)]
-    fn just_push_row(&mut self, grammar_id: LexemeClass, lex_start: Option<StateID>) -> bool {
+    fn just_push_row(
+        &mut self,
+        grammar_id: LexemeClass,
+        lex_start: Option<StateID>,
+        allow_skip: bool,
+    ) -> bool {
         let row_len = self.scratch.row_len();
 
         self.stats.rows += 1;
@@ -2049,12 +2065,36 @@ impl ParserState {
                 l
             } else {
                 // accept a SKIP lexeme, if the grammar didn't finish
-                if self
-                    .scratch
-                    .push_allowed_grammar_ids
-                    .get(grammar_id.as_usize())
-                {
-                    let skip = self.lexer_spec().skip_id(grammar_id);
+                let mut skip_grammar_id = None;
+                if allow_skip {
+                    if self
+                        .scratch
+                        .push_allowed_grammar_ids
+                        .get(grammar_id.as_usize())
+                    {
+                        skip_grammar_id = Some(grammar_id);
+                    } else {
+                        // A nested grammar may have completed on this lexeme. Find the
+                        // nearest parent grammar that can accept the next lexeme.
+                        let mut ptr = self.scratch.push_grm_top;
+                        while ptr.as_usize() > 0 {
+                            let top = &self.scratch.grammar_stack[ptr.as_usize()];
+                            ptr = top.back_ptr;
+                            let parent_id = self.scratch.grammar_stack[ptr.as_usize()].grammar_id;
+                            if self
+                                .scratch
+                                .push_allowed_grammar_ids
+                                .get(parent_id.as_usize())
+                            {
+                                skip_grammar_id = Some(parent_id);
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if let Some(skip_grammar_id) = skip_grammar_id {
+                    let skip = self.lexer_spec().skip_id(skip_grammar_id);
                     self.scratch.push_allowed_lexemes.add(skip);
                 }
 
@@ -2146,7 +2186,7 @@ impl ParserState {
             self.process_max_tokens(ptr, lexeme);
         }
 
-        self.just_push_row(grammar_id, None)
+        self.just_push_row(grammar_id, None, true)
     }
 
     fn mk_grammar_stack_node(&self, sym_data: &CSymbol, curr_idx: usize) -> GrammarStackNode {

--- a/parser/src/grammar_builder.rs
+++ b/parser/src/grammar_builder.rs
@@ -212,10 +212,18 @@ impl GrammarBuilder {
         warnings
     }
 
-    pub fn add_grammar(&mut self, options: LLGuidanceOptions, skip: SkipSpec) -> Result<SymIdx> {
+    pub fn add_grammar(&mut self, options: LLGuidanceOptions, skip: RegexAst) -> Result<SymIdx> {
+        self.add_grammar_with_skip(options, SkipSpec::unbounded(skip))
+    }
+
+    pub fn add_grammar_with_skip(
+        &mut self,
+        options: LLGuidanceOptions,
+        skip: SkipSpec,
+    ) -> Result<SymIdx> {
         self.check_limits()?;
 
-        self.curr_lexeme_class = self.regex.spec.setup_lexeme_class(skip)?;
+        self.curr_lexeme_class = self.regex.spec.setup_lexeme_class_with_skip(skip)?;
 
         self.strings.clear();
         self.at_most_cache.clear();

--- a/parser/src/grammar_builder.rs
+++ b/parser/src/grammar_builder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{LLGuidanceOptions, ParserLimits},
+    api::{LLGuidanceOptions, ParserLimits, SkipSpec},
     earley::{
         lexerspec::{token_ranges_to_string, LexemeClass, LexemeIdx, LexerSpec},
         Grammar, ParamCond, ParamExpr, SymIdx, SymbolProps,
@@ -212,13 +212,10 @@ impl GrammarBuilder {
         warnings
     }
 
-    pub fn add_grammar(&mut self, options: LLGuidanceOptions, skip: RegexAst) -> Result<SymIdx> {
+    pub fn add_grammar(&mut self, options: LLGuidanceOptions, skip: SkipSpec) -> Result<SymIdx> {
         self.check_limits()?;
 
-        self.curr_lexeme_class = self
-            .regex
-            .spec
-            .setup_lexeme_class(skip, options.skip_repetition)?;
+        self.curr_lexeme_class = self.regex.spec.setup_lexeme_class(skip)?;
 
         self.strings.clear();
         self.at_most_cache.clear();

--- a/parser/src/grammar_builder.rs
+++ b/parser/src/grammar_builder.rs
@@ -215,7 +215,10 @@ impl GrammarBuilder {
     pub fn add_grammar(&mut self, options: LLGuidanceOptions, skip: RegexAst) -> Result<SymIdx> {
         self.check_limits()?;
 
-        self.curr_lexeme_class = self.regex.spec.setup_lexeme_class(skip)?;
+        self.curr_lexeme_class = self
+            .regex
+            .spec
+            .setup_lexeme_class(skip, options.skip_repetition)?;
 
         self.strings.clear();
         self.at_most_cache.clear();

--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -1,4 +1,4 @@
-use crate::api::{LLGuidanceOptions, SkipRepetition};
+use crate::api::{LLGuidanceOptions, SkipSpec};
 use crate::grammar_builder::GrammarResult;
 use crate::json::schema::{NumberSchema, StringSchema};
 use crate::{regex_to_lark, HashMap};
@@ -157,13 +157,9 @@ impl Compiler {
         } else {
             RegexAst::NoMatch
         };
-        let id = self.builder.add_grammar(
-            LLGuidanceOptions {
-                skip_repetition: SkipRepetition::Once,
-                ..Default::default()
-            },
-            skip,
-        )?;
+        let id = self
+            .builder
+            .add_grammar(LLGuidanceOptions::default(), SkipSpec::once(skip))?;
 
         let built = build_schema(schema, &self.options)?;
         self.pattern_cache = built.pattern_cache;

--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -159,7 +159,7 @@ impl Compiler {
         };
         let id = self
             .builder
-            .add_grammar(LLGuidanceOptions::default(), SkipSpec::once(skip))?;
+            .add_grammar_with_skip(LLGuidanceOptions::default(), SkipSpec::once(skip))?;
 
         let built = build_schema(schema, &self.options)?;
         self.pattern_cache = built.pattern_cache;

--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -1,4 +1,4 @@
-use crate::api::LLGuidanceOptions;
+use crate::api::{LLGuidanceOptions, SkipRepetition};
 use crate::grammar_builder::GrammarResult;
 use crate::json::schema::{NumberSchema, StringSchema};
 use crate::{regex_to_lark, HashMap};
@@ -157,9 +157,13 @@ impl Compiler {
         } else {
             RegexAst::NoMatch
         };
-        let id = self
-            .builder
-            .add_grammar(LLGuidanceOptions::default(), skip)?;
+        let id = self.builder.add_grammar(
+            LLGuidanceOptions {
+                skip_repetition: SkipRepetition::Once,
+                ..Default::default()
+            },
+            skip,
+        )?;
 
         let built = build_schema(schema, &self.options)?;
         self.pattern_cache = built.pattern_cache;

--- a/parser/src/lark/compiler.rs
+++ b/parser/src/lark/compiler.rs
@@ -10,8 +10,7 @@ use serde::Deserialize;
 
 use crate::{
     api::{
-        GenGrammarOptions, GenOptions, GrammarId, LLGuidanceOptions, NodeProps, RegexExt,
-        SkipRepetition, SkipSpec,
+        GenGrammarOptions, GenOptions, GrammarId, LLGuidanceOptions, NodeProps, RegexExt, SkipSpec,
     },
     json::json_merge,
     substring::{chunk_into_chars, chunk_into_words},
@@ -27,14 +26,14 @@ use super::{
 
 const DEBUG: bool = false;
 
-/// Options accepted by Lark's `%llguidance` directive. Skip repetition is
+/// Options accepted by Lark's `%llguidance` directive. `ignore_once` is
 /// Lark-specific because it controls how `%ignore` expressions are compiled.
 #[derive(Debug, Default, Deserialize)]
 struct LarkLLGuidanceOptions {
     #[serde(flatten)]
     general: LLGuidanceOptions,
     #[serde(default)]
-    skip_repetition: SkipRepetition,
+    ignore_once: bool,
 }
 
 macro_rules! debug {
@@ -668,7 +667,12 @@ impl Compiler {
             .into_iter()
             .map(|exp| Ok(RegexAst::ExprRef(self.do_token_expansions(exp)?)))
             .collect::<Result<Vec<_>>>()?;
-        let skip = SkipSpec::new(RegexAst::Or(ignore), opts.skip_repetition);
+        let skip_regex = RegexAst::Or(ignore);
+        let skip = if opts.ignore_once {
+            SkipSpec::once(skip_regex)
+        } else {
+            SkipSpec::unbounded(skip_regex)
+        };
         let id = self.builder.add_grammar_with_skip(opts.general, skip)?;
 
         let start = self.do_rule(start_name, None)?;

--- a/parser/src/lark/compiler.rs
+++ b/parser/src/lark/compiler.rs
@@ -669,7 +669,7 @@ impl Compiler {
             .map(|exp| Ok(RegexAst::ExprRef(self.do_token_expansions(exp)?)))
             .collect::<Result<Vec<_>>>()?;
         let skip = SkipSpec::new(RegexAst::Or(ignore), opts.skip_repetition);
-        let id = self.builder.add_grammar(opts.general, skip)?;
+        let id = self.builder.add_grammar_with_skip(opts.general, skip)?;
 
         let start = self.do_rule(start_name, None)?;
         self.builder.set_start_node(start);

--- a/parser/src/lark/compiler.rs
+++ b/parser/src/lark/compiler.rs
@@ -6,9 +6,13 @@ use crate::{
 };
 use anyhow::{anyhow, bail, ensure, Result};
 use derivre::RegexAst;
+use serde::Deserialize;
 
 use crate::{
-    api::{GenGrammarOptions, GenOptions, GrammarId, LLGuidanceOptions, NodeProps, RegexExt},
+    api::{
+        GenGrammarOptions, GenOptions, GrammarId, LLGuidanceOptions, NodeProps, RegexExt,
+        SkipRepetition, SkipSpec,
+    },
     json::json_merge,
     substring::{chunk_into_chars, chunk_into_words},
     GrammarBuilder, JsonCompileOptions, NodeRef,
@@ -22,6 +26,15 @@ use super::{
 };
 
 const DEBUG: bool = false;
+
+#[derive(Debug, Default, Deserialize)]
+struct LarkLLGuidanceOptions {
+    #[serde(flatten)]
+    general: LLGuidanceOptions,
+    #[serde(default)]
+    skip_repetition: SkipRepetition,
+}
+
 macro_rules! debug {
     ($($arg:tt)*) => {
         if cfg!(feature = "logging") && DEBUG {
@@ -645,7 +658,7 @@ impl Compiler {
         let ignore = std::mem::take(&mut grm.ignore);
         self.grammar = grm;
 
-        let opts: LLGuidanceOptions =
+        let opts: LarkLLGuidanceOptions =
             serde_json::from_value(self.grammar.llguidance_options.clone())
                 .map_err(|e| anyhow!("failed to parse %llguidance declaration: {}", e))?;
 
@@ -653,7 +666,8 @@ impl Compiler {
             .into_iter()
             .map(|exp| Ok(RegexAst::ExprRef(self.do_token_expansions(exp)?)))
             .collect::<Result<Vec<_>>>()?;
-        let id = self.builder.add_grammar(opts, RegexAst::Or(ignore))?;
+        let skip = SkipSpec::new(RegexAst::Or(ignore), opts.skip_repetition);
+        let id = self.builder.add_grammar(opts.general, skip)?;
 
         let start = self.do_rule(start_name, None)?;
         self.builder.set_start_node(start);
@@ -725,7 +739,7 @@ impl Grammar {
                 // merge-in at the JSON level
                 json_merge(&mut self.llguidance_options, &json_value);
                 // but also check if it's valid format and all the right types
-                let _v: LLGuidanceOptions = serde_json::from_value(json_value)
+                let _v: LarkLLGuidanceOptions = serde_json::from_value(json_value)
                     .map_err(|e| anyhow!("failed to parse %llguidance declaration: {}", e))?;
             }
             Statement::OverrideRule(_) => {

--- a/parser/src/lark/compiler.rs
+++ b/parser/src/lark/compiler.rs
@@ -27,6 +27,8 @@ use super::{
 
 const DEBUG: bool = false;
 
+/// Options accepted by Lark's `%llguidance` directive. Skip repetition is
+/// Lark-specific because it controls how `%ignore` expressions are compiled.
 #[derive(Debug, Default, Deserialize)]
 struct LarkLLGuidanceOptions {
     #[serde(flatten)]

--- a/parser/src/lark/lexer.rs
+++ b/parser/src/lark/lexer.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    api::{RegexExt, SkipRepetition},
+    api::{RegexExt, SkipSpec},
     HashMap,
 };
 use anyhow::{anyhow, bail, Result};
@@ -236,7 +236,7 @@ pub fn lex_lark(input: &str) -> Result<Vec<Lexeme>> {
     let comment_or_ws = r"((#|//)[^\n]*)|[ \t]+".to_string();
     let mut spec = LexerSpec::new().unwrap();
     let cls = spec
-        .setup_lexeme_class(RegexAst::Regex(comment_or_ws), SkipRepetition::Unbounded)
+        .setup_lexeme_class(SkipSpec::unbounded(RegexAst::Regex(comment_or_ws)))
         .unwrap();
     let mut lexeme_idx_to_token = HashMap::default();
     lexeme_idx_to_token.insert(spec.skip_id(cls), Token::SKIP);

--- a/parser/src/lark/lexer.rs
+++ b/parser/src/lark/lexer.rs
@@ -236,7 +236,7 @@ pub fn lex_lark(input: &str) -> Result<Vec<Lexeme>> {
     let comment_or_ws = r"((#|//)[^\n]*)|[ \t]+".to_string();
     let mut spec = LexerSpec::new().unwrap();
     let cls = spec
-        .setup_lexeme_class(SkipSpec::unbounded(RegexAst::Regex(comment_or_ws)))
+        .setup_lexeme_class_with_skip(SkipSpec::unbounded(RegexAst::Regex(comment_or_ws)))
         .unwrap();
     let mut lexeme_idx_to_token = HashMap::default();
     lexeme_idx_to_token.insert(spec.skip_id(cls), Token::SKIP);

--- a/parser/src/lark/lexer.rs
+++ b/parser/src/lark/lexer.rs
@@ -3,7 +3,10 @@ use std::{
     rc::Rc,
 };
 
-use crate::{api::RegexExt, HashMap};
+use crate::{
+    api::{RegexExt, SkipRepetition},
+    HashMap,
+};
 use anyhow::{anyhow, bail, Result};
 use derivre::RegexAst;
 use serde::de;
@@ -233,7 +236,7 @@ pub fn lex_lark(input: &str) -> Result<Vec<Lexeme>> {
     let comment_or_ws = r"((#|//)[^\n]*)|[ \t]+".to_string();
     let mut spec = LexerSpec::new().unwrap();
     let cls = spec
-        .setup_lexeme_class(RegexAst::Regex(comment_or_ws))
+        .setup_lexeme_class(RegexAst::Regex(comment_or_ws), SkipRepetition::Unbounded)
         .unwrap();
     let mut lexeme_idx_to_token = HashMap::default();
     lexeme_idx_to_token.insert(spec.skip_id(cls), Token::SKIP);

--- a/parser/tests/test_json_x_guidance.rs
+++ b/parser/tests/test_json_x_guidance.rs
@@ -364,3 +364,24 @@ fn whitespace_flexible_many_formats(
     );
     lark_str_test(&lark, true, &target_str, true);
 }
+
+#[rstest]
+#[case::compact(r#"{"a":1}"#, true)]
+#[case::within_bound(r#"{  "a"  :  1  }"#, true)]
+#[case::after_open_over_bound(r#"{   "a":1}"#, false)]
+#[case::before_close_over_bound(r#"{"a":1   }"#, false)]
+fn whitespace_pattern_bounds_entire_gap(#[case] input: &str, #[case] should_succeed: bool) {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "a": { "type": "integer" }
+        },
+        "required": ["a"],
+        "additionalProperties": false,
+        "x-guidance": {
+            "whitespace_pattern": r"\s{1,2}"
+        }
+    });
+    let lark = format!("start: %json {schema}");
+    lark_str_test(&lark, should_succeed, input, true);
+}

--- a/parser/tests/test_lark.rs
+++ b/parser/tests/test_lark.rs
@@ -248,7 +248,7 @@ fn test_lark_syntax_perc() {
     );
     lark_err_test(
         r#"
-            %llguidance { "skip_repetition": "many" }
+            %llguidance { "ignore_once": "yes" }
             start: "a" | "b"
         "#,
         "failed to parse %llguidance declaration",

--- a/parser/tests/test_lark.rs
+++ b/parser/tests/test_lark.rs
@@ -246,6 +246,13 @@ fn test_lark_syntax_perc() {
         "#,
         "failed to parse %llguidance declaration",
     );
+    lark_err_test(
+        r#"
+            %llguidance { "skip_repetition": "many" }
+            start: "a" | "b"
+        "#,
+        "failed to parse %llguidance declaration",
+    );
 
     lark_ok(r#" start: %regex { "substring_words": "foo bar" } "#);
     lark_ok(r#" start: %regex { "substring_chars": "foo bar" } "#);

--- a/parser/tests/test_ll.rs
+++ b/parser/tests/test_ll.rs
@@ -32,7 +32,7 @@ fn test_ll_skip() {
     );
 
     let bounded_skip = r#"
-        %llguidance { "skip_repetition": "once" }
+        %llguidance { "ignore_once": true }
         start: "A" "!"
         %ignore /[ \t]{1,2}/
     "#;
@@ -69,7 +69,7 @@ fn test_outer_skip_after_once_skip_hits_max_tokens() {
     let grammar = r#"
         start: sub "y"
         sub[max_tokens=1]: %lark {
-            %llguidance { "skip_repetition": "once" }
+            %llguidance { "ignore_once": true }
             start: "a" "b"
             %ignore /[ ]/
         }

--- a/parser/tests/test_ll.rs
+++ b/parser/tests/test_ll.rs
@@ -30,6 +30,38 @@ fn test_ll_skip() {
            %ignore /[ \t]+/"#,
         &[".‧A", " ‧ ‧!"],
     );
+
+    let bounded_skip = r#"
+        %llguidance { "skip_repetition": "once" }
+        start: "A" "!"
+        %ignore /[ \t]{1,2}/
+    "#;
+    lark_str_test(bounded_skip, true, "A!", true);
+    lark_str_test(bounded_skip, true, "A !", true);
+    lark_str_test(bounded_skip, true, "A  !", true);
+    lark_str_test(bounded_skip, false, "A   !", true);
+
+    let legacy_skip = r#"
+        start: "A" "!"
+        %ignore /[ \t]/
+    "#;
+    lark_str_test(legacy_skip, true, "A   !", true);
+}
+
+#[test]
+fn test_outer_skip_after_nested_json() {
+    let grammar = r#"
+        start: "BEGIN" payload "END"
+        payload: %json {
+            "type": "object",
+            "additionalProperties": false
+        }
+        %ignore /[\x20\x0A\x0D\x09]+/
+    "#;
+
+    lark_str_test(grammar, true, "BEGIN{} END", true);
+    lark_str_test(grammar, true, "BEGIN{}   END", true);
+    lark_str_test(grammar, true, "BEGIN{ } END", true);
 }
 
 #[test]

--- a/parser/tests/test_ll.rs
+++ b/parser/tests/test_ll.rs
@@ -65,6 +65,23 @@ fn test_outer_skip_after_nested_json() {
 }
 
 #[test]
+fn test_outer_skip_after_once_skip_hits_max_tokens() {
+    check_lark_grammar_nested(
+        r#"
+            start: sub "y"
+            sub[max_tokens=1]: @sub
+            %ignore /[ ]+/
+        "#,
+        r#"
+            %llguidance { "skip_repetition": "once" }
+            start: "a" "b"
+            %ignore /[ ]/
+        "#,
+        &["", "a‧ ‧ ‧y"],
+    );
+}
+
+#[test]
 fn test_ll_format() {
     check_lark_json(
         r#"start: "JSON" @sub

--- a/parser/tests/test_ll.rs
+++ b/parser/tests/test_ll.rs
@@ -66,19 +66,17 @@ fn test_outer_skip_after_nested_json() {
 
 #[test]
 fn test_outer_skip_after_once_skip_hits_max_tokens() {
-    check_lark_grammar_nested(
-        r#"
-            start: sub "y"
-            sub[max_tokens=1]: @sub
-            %ignore /[ ]+/
-        "#,
-        r#"
+    let grammar = r#"
+        start: sub "y"
+        sub[max_tokens=1]: %lark {
             %llguidance { "skip_repetition": "once" }
             start: "a" "b"
             %ignore /[ ]/
-        "#,
-        &["", "a‧ ‧ ‧y"],
-    );
+        }
+        %ignore /[ ]+/
+    "#;
+
+    lark_str_test(grammar, true, "a  y", true);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add single-match behavior for skip lexemes: the lexemes generated from Lark `%ignore` directives and JSON `whitespace_pattern`. This prevents the skip regex from being reapplied indefinitely, so bounds such as `{1,8}` are enforced.

```lark
%llguidance { "ignore_once": true }
start: "A" "!"
%ignore /[ \t]{1,8}/
```

JSON `whitespace_pattern` automatically uses this behavior:

```json
{
  "x-guidance": {
    "whitespace_pattern": "[\\x20\\x0A\\x0D\\x09]{1,8}"
  }
}
```

## Motivation

Skip lexemes were previously accepted repeatedly. Consequently, patterns such as `\s` and `\s{1,8}` were effectively unbounded, making it difficult to constrain whitespace during LLM generation.

## Implementation

Skip configuration is represented internally by a `SkipSpec` containing the regex and its repetition behavior. Lark exposes the behavior as the boolean `%llguidance` option `ignore_once`.

After a once-mode skip is scanned, the parser copies the Earley row as before but removes that skip lexeme from the copied row's lexer state. Scanning an ordinary lexeme re-enables skip at the next grammar position.

This avoids grammar expansion, repetition counters, and per-token overhead. Nested grammar completion and `max_tokens` pops restore the appropriate parent skip configuration.

Existing `GrammarBuilder::add_grammar` and `LexerSpec::setup_lexeme_class` APIs remain available with their original unbounded behavior.

## Compatibility

Lark grammars remain unbounded by default; `ignore_once: true` is opt-in.

Default JSON behavior is unchanged:

- `whitespace_flexible: true` uses `[\x20\x0A\x0D\x09]+`.
- `whitespace_flexible: false` disables whitespace skip.

This is behavior-changing but effectively a bug fix for explicit `whitespace_pattern` values. Patterns such as `\s` or `\s{1,8}` are now matched at most once at each permitted whitespace location, so their upper bounds are enforced. Callers intentionally relying on repeated matching can express that repetition directly in the regex, for example `\s+`.

## Coverage

Tests cover:

- Legacy unbounded skip behavior
- Bounded Lark skip with `ignore_once: true`
- Bounded JSON whitespace
- Invalid `ignore_once` values
- Nested grammar skip restoration
- Parent skip restoration after `max_tokens`

Closes #247.
