### PR TITLE
Report empty integer intervals as unsatisfiable

### DIFF
--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -8,7 +8,7 @@ use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use super::numeric::{check_number_bounds, rx_float_range, rx_int_range};
+use super::numeric::{check_number_bounds, normalize_integer_bounds, rx_float_range, rx_int_range};
 use super::schema::{build_schema, ArraySchema, ObjectSchema, OptSchemaExt, Schema};
 use super::shared_context::PatternPropertyCache;
 use super::RetrieveWrapper;
@@ -273,35 +273,7 @@ impl Compiler {
                 message: e.to_string(),
             })
         })?;
-        let minimum = match num.get_minimum() {
-            (Some(min_val), true) => {
-                if min_val.fract() != 0.0 {
-                    Some(min_val.ceil())
-                } else {
-                    Some(min_val + 1.0)
-                }
-            }
-            (Some(min_val), false) => Some(min_val.ceil()),
-            _ => None,
-        }
-        .map(|val| val as i64);
-        let maximum = match num.get_maximum() {
-            (Some(max_val), true) => {
-                if max_val.fract() != 0.0 {
-                    Some(max_val.floor())
-                } else {
-                    Some(max_val - 1.0)
-                }
-            }
-            (Some(max_val), false) => Some(max_val.floor()),
-            _ => None,
-        }
-        .map(|val| val as i64);
-        if matches!((minimum, maximum), (Some(min), Some(max)) if min > max) {
-            return Err(anyhow!(UnsatisfiableSchemaError {
-                message: "integer bounds contain no integer values".to_string(),
-            }));
-        }
+        let (minimum, maximum) = normalize_integer_bounds(num);
         let rx = rx_int_range(minimum, maximum).with_context(|| {
             format!("Failed to generate regex for integer range: min={minimum:?}, max={maximum:?}")
         })?;

--- a/parser/src/json/compiler.rs
+++ b/parser/src/json/compiler.rs
@@ -297,6 +297,11 @@ impl Compiler {
             _ => None,
         }
         .map(|val| val as i64);
+        if matches!((minimum, maximum), (Some(min), Some(max)) if min > max) {
+            return Err(anyhow!(UnsatisfiableSchemaError {
+                message: "integer bounds contain no integer values".to_string(),
+            }));
+        }
         let rx = rx_int_range(minimum, maximum).with_context(|| {
             format!("Failed to generate regex for integer range: min={minimum:?}, max={maximum:?}")
         })?;

--- a/parser/src/json/numeric.rs
+++ b/parser/src/json/numeric.rs
@@ -506,6 +506,42 @@ pub fn rx_float_range(
     }
 }
 
+pub(super) fn normalize_integer_bounds(num: &NumberSchema) -> (Option<i64>, Option<i64>) {
+    let minimum = match num.get_minimum() {
+        (Some(min_val), true) => {
+            if min_val.fract() != 0.0 {
+                Some(min_val.ceil())
+            } else {
+                Some(min_val + 1.0)
+            }
+        }
+        (Some(min_val), false) => Some(min_val.ceil()),
+        _ => None,
+    }
+    .map(|val| val as i64);
+    let maximum = match num.get_maximum() {
+        (Some(max_val), true) => {
+            if max_val.fract() != 0.0 {
+                Some(max_val.floor())
+            } else {
+                Some(max_val - 1.0)
+            }
+        }
+        (Some(max_val), false) => Some(max_val.floor()),
+        _ => None,
+    }
+    .map(|val| val as i64);
+    (minimum, maximum)
+}
+
+fn check_integer_bounds(num: &NumberSchema) -> Result<(), String> {
+    let (minimum, maximum) = normalize_integer_bounds(num);
+    if matches!((minimum, maximum), (Some(min), Some(max)) if min > max) {
+        return Err("integer bounds contain no integer values".to_string());
+    }
+    Ok(())
+}
+
 pub fn check_number_bounds(num: &NumberSchema) -> Result<(), String> {
     let (minimum, exclusive_minimum) = num.get_minimum();
     let (maximum, exclusive_maximum) = num.get_maximum();
@@ -530,6 +566,9 @@ pub fn check_number_bounds(num: &NumberSchema) -> Result<(), String> {
                 "{minimum_repr} ({min}) is equal to {maximum_repr} ({max})"
             ));
         }
+    }
+    if num.integer {
+        check_integer_bounds(num)?;
     }
     if let Some(d) = num.multiple_of.as_ref() {
         if d.coef == 0 {
@@ -933,6 +972,62 @@ mod test_number_bounds {
     #[test]
     fn test_check_number_bounds() {
         let cases = vec![
+            // Integer bounds can be empty even when the corresponding real interval is not.
+            Case {
+                minimum: Some(0.0),
+                maximum: Some(1.0),
+                exclusive_minimum: true,
+                exclusive_maximum: true,
+                integer: true,
+                multiple_of: None,
+                ok: false,
+            },
+            Case {
+                minimum: Some(0.0),
+                maximum: Some(1.0),
+                exclusive_minimum: true,
+                exclusive_maximum: true,
+                integer: false,
+                multiple_of: None,
+                ok: true,
+            },
+            Case {
+                minimum: Some(0.1),
+                maximum: Some(0.9),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: true,
+                multiple_of: None,
+                ok: false,
+            },
+            Case {
+                minimum: Some(0.1),
+                maximum: Some(0.9),
+                exclusive_minimum: false,
+                exclusive_maximum: false,
+                integer: false,
+                multiple_of: None,
+                ok: true,
+            },
+            // Equal normalized integer endpoints represent valid singleton intervals.
+            Case {
+                minimum: Some(0.0),
+                maximum: Some(1.0),
+                exclusive_minimum: true,
+                exclusive_maximum: false,
+                integer: true,
+                multiple_of: None,
+                ok: true,
+            },
+            Case {
+                minimum: Some(0.0),
+                maximum: Some(1.0),
+                exclusive_minimum: false,
+                exclusive_maximum: true,
+                integer: true,
+                multiple_of: None,
+                ok: true,
+            },
             Case {
                 minimum: Some(5.5),
                 maximum: Some(6.0),

--- a/parser/src/json/numeric.rs
+++ b/parser/src/json/numeric.rs
@@ -534,14 +534,6 @@ pub(super) fn normalize_integer_bounds(num: &NumberSchema) -> (Option<i64>, Opti
     (minimum, maximum)
 }
 
-fn check_integer_bounds(num: &NumberSchema) -> Result<(), String> {
-    let (minimum, maximum) = normalize_integer_bounds(num);
-    if matches!((minimum, maximum), (Some(min), Some(max)) if min > max) {
-        return Err("integer bounds contain no integer values".to_string());
-    }
-    Ok(())
-}
-
 pub fn check_number_bounds(num: &NumberSchema) -> Result<(), String> {
     let (minimum, exclusive_minimum) = num.get_minimum();
     let (maximum, exclusive_maximum) = num.get_maximum();
@@ -566,9 +558,19 @@ pub fn check_number_bounds(num: &NumberSchema) -> Result<(), String> {
                 "{minimum_repr} ({min}) is equal to {maximum_repr} ({max})"
             ));
         }
-    }
-    if num.integer {
-        check_integer_bounds(num)?;
+        if num.integer {
+            let (integer_minimum, integer_maximum) = normalize_integer_bounds(num);
+            if matches!(
+                (integer_minimum, integer_maximum),
+                (Some(integer_min), Some(integer_max)) if integer_min > integer_max
+            ) {
+                let left_bracket = if exclusive_minimum { '(' } else { '[' };
+                let right_bracket = if exclusive_maximum { ')' } else { ']' };
+                return Err(format!(
+                    "integer interval {left_bracket}{min}, {max}{right_bracket} contains no integer values"
+                ));
+            }
+        }
     }
     if let Some(d) = num.multiple_of.as_ref() {
         if d.coef == 0 {

--- a/parser/tests/test_json_primitives.rs
+++ b/parser/tests/test_json_primitives.rs
@@ -189,11 +189,46 @@ fn integer_limits_incompatible(
     "minimum": 0.1,
     "maximum": 0.9
 }))]
+#[case::before_multiple_of(&json!({
+    "type": "integer",
+    "minimum": 0.1,
+    "maximum": 0.9,
+    "multipleOf": 1
+}))]
 fn integer_limits_empty(#[case] schema: &Value) {
     json_err_test(
         schema,
         "Unsatisfiable schema: integer bounds contain no integer values",
     );
+}
+
+#[rstest]
+#[case::exclusive_minimum_accepts_one(
+    &json!({"type": "integer", "exclusiveMinimum": 0, "maximum": 1}),
+    &json!(1),
+    true
+)]
+#[case::exclusive_minimum_rejects_zero(
+    &json!({"type": "integer", "exclusiveMinimum": 0, "maximum": 1}),
+    &json!(0),
+    false
+)]
+#[case::exclusive_maximum_accepts_zero(
+    &json!({"type": "integer", "minimum": 0, "exclusiveMaximum": 1}),
+    &json!(0),
+    true
+)]
+#[case::exclusive_maximum_rejects_one(
+    &json!({"type": "integer", "minimum": 0, "exclusiveMaximum": 1}),
+    &json!(1),
+    false
+)]
+fn integer_limits_singleton(
+    #[case] schema: &Value,
+    #[case] sample: &Value,
+    #[case] should_pass: bool,
+) {
+    json_schema_check(schema, sample, should_pass);
 }
 
 #[rstest]

--- a/parser/tests/test_json_primitives.rs
+++ b/parser/tests/test_json_primitives.rs
@@ -183,23 +183,20 @@ fn integer_limits_incompatible(
     "type": "integer",
     "exclusiveMinimum": 0,
     "exclusiveMaximum": 1
-}))]
+}), "Unsatisfiable schema: integer interval (0, 1) contains no integer values")]
 #[case::fractional_bounds(&json!({
     "type": "integer",
     "minimum": 0.1,
     "maximum": 0.9
-}))]
+}), "Unsatisfiable schema: integer interval [0.1, 0.9] contains no integer values")]
 #[case::before_multiple_of(&json!({
     "type": "integer",
     "minimum": 0.1,
     "maximum": 0.9,
     "multipleOf": 1
-}))]
-fn integer_limits_empty(#[case] schema: &Value) {
-    json_err_test(
-        schema,
-        "Unsatisfiable schema: integer bounds contain no integer values",
-    );
+}), "Unsatisfiable schema: integer interval [0.1, 0.9] contains no integer values")]
+fn integer_limits_empty(#[case] schema: &Value, #[case] expected: &str) {
+    json_err_test(schema, expected);
 }
 
 #[rstest]

--- a/parser/tests/test_json_primitives.rs
+++ b/parser/tests/test_json_primitives.rs
@@ -179,13 +179,20 @@ fn integer_limits_incompatible(
 }
 
 #[rstest]
-fn integer_limits_empty() {
+#[case::exclusive_bounds(&json!({
+    "type": "integer",
+    "exclusiveMinimum": 0,
+    "exclusiveMaximum": 1
+}))]
+#[case::fractional_bounds(&json!({
+    "type": "integer",
+    "minimum": 0.1,
+    "maximum": 0.9
+}))]
+fn integer_limits_empty(#[case] schema: &Value) {
     json_err_test(
-        &json!({
-            "type": "integer",
-            "exclusiveMinimum": 0, "exclusiveMaximum": 1
-        }),
-        "Failed to generate regex for integer range",
+        schema,
+        "Unsatisfiable schema: integer bounds contain no integer values",
     );
 }
 


### PR DESCRIPTION
Fixes #206

Returns UnsatisfiableSchemaError when integer bounds contain no valid integer values, instead of exposing a regex-generation error.