### PR TITLE
Scope JSON Schema test suite panic suppression

### DIFF
--- a/json_schema_test_suite/src/main.rs
+++ b/json_schema_test_suite/src/main.rs
@@ -18,7 +18,7 @@
 /// With --draft, only the specified draft(s) are run.
 use anyhow::{bail, Result};
 use clap::Parser;
-use llg_test_utils::{json_schema_check, make_parser};
+use llg_test_utils::{json_schema_accepts, make_parser};
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -132,18 +132,13 @@ fn run_test_file(path: &Path, prefix: &str, results: &mut Results) {
             }
             Ok(_) => {
                 for test in &group.tests {
-                    let result = std::panic::catch_unwind(|| {
-                        json_schema_check(&group.schema, &test.data, test.valid);
-                    });
-                    let category = match result {
-                        Ok(()) => "pass",
-                        Err(_) => {
-                            if test.valid {
-                                "false_negative"
-                            } else {
-                                "false_positive"
-                            }
-                        }
+                    let accepted = json_schema_accepts(&group.schema, &test.data);
+                    let category = if accepted == test.valid {
+                        "pass"
+                    } else if test.valid {
+                        "false_negative"
+                    } else {
+                        "false_positive"
                     };
                     group_results.insert(test.description.clone(), category.to_string());
                 }
@@ -348,9 +343,6 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    // Suppress panic messages from catch_unwind (expected for false_negative/false_positive cases)
-    std::panic::set_hook(Box::new(|_| {}));
-
     let args = Args::parse();
     llg_test_utils::set_quiet_mode(!args.verbose);
     let mut drafts_arg = args.draft;

--- a/json_schema_test_suite/tests/panic_reporting.rs
+++ b/json_schema_test_suite/tests/panic_reporting.rs
@@ -1,0 +1,87 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TestSuite {
+    root: PathBuf,
+}
+
+impl TestSuite {
+    fn with_test_file(contents: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "llguidance-json-schema-panic-reporting-{}-{unique}",
+            std::process::id()
+        ));
+        let draft_dir = root.join("tests").join("draft2020-12");
+        std::fs::create_dir_all(&draft_dir).unwrap();
+        std::fs::write(draft_dir.join("fixture.json"), contents).unwrap();
+        Self { root }
+    }
+
+    fn run(&self) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_json_schema_test_suite"))
+            .args(["--draft", "draft2020-12"])
+            .arg(self.path())
+            .output()
+            .unwrap()
+    }
+
+    fn path(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl Drop for TestSuite {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.root).unwrap();
+    }
+}
+
+#[test]
+fn unexpected_panics_are_reported() {
+    let suite = TestSuite::with_test_file("not valid JSON");
+    let output = suite.run();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(
+        stderr.contains("panicked at"),
+        "unexpected panic diagnostic was suppressed; stderr: {stderr:?}"
+    );
+}
+
+#[test]
+fn expected_mismatches_remain_quiet_and_classified() {
+    let suite = TestSuite::with_test_file(
+        r#"[
+            {
+                "description": "intentional mismatch",
+                "schema": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "integer"
+                },
+                "tests": [
+                    {
+                        "description": "deliberately mislabeled valid",
+                        "data": "not an integer",
+                        "valid": true
+                    }
+                ]
+            }
+        ]"#,
+    );
+    let output = suite.run();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(stdout.contains(r#""deliberately mislabeled valid": "false_negative""#));
+    assert!(
+        !stderr.contains("panicked at"),
+        "expected mismatch emitted a panic diagnostic: {stderr}"
+    );
+}

--- a/llg_test_utils/src/acceptance.rs
+++ b/llg_test_utils/src/acceptance.rs
@@ -141,12 +141,12 @@ pub fn lark_str_test_many_ext(quiet: bool, lark: &str, passing: &[&str], failing
 
 // ── JSON schema testing ─────────────────────────────────────────────────────
 
-/// Check that a JSON value is accepted or rejected by a JSON-schema grammar.
-///
-/// Unlike [`lark_str_test`], this function does not use the `FINAL_REJECT:`
-/// convention.  Instead it serialises `json_obj`, feeds the tokens, and
-/// compares the parser's final `is_accepting()` state to `expect_valid`.
-pub fn json_schema_check(schema: &Value, json_obj: &Value, expect_valid: bool) {
+enum JsonSchemaMatch {
+    Complete(bool),
+    RejectedAt { token: String, index: usize },
+}
+
+fn json_schema_match(schema: &Value, json_obj: &Value) -> JsonSchemaMatch {
     /*
        This is a modification of the lark_str_test function, which makes the
        assumption that the input Value completely satifies the schema.
@@ -171,12 +171,10 @@ pub fn json_schema_check(schema: &Value, json_obj: &Value, expect_valid: bool) {
         if m.is_allowed(*tok) {
             consume(&mut p, *tok);
         } else {
-            let curr_tok_str = get_tok_env().tok_trie().token_dbg(*tok);
-            assert!(
-                !expect_valid,
-                "Unexpected token: {curr_tok_str} at token index {i}",
-            );
-            return;
+            return JsonSchemaMatch::RejectedAt {
+                token: get_tok_env().tok_trie().token_dbg(*tok),
+                index: i,
+            };
         }
     }
 
@@ -186,7 +184,34 @@ pub fn json_schema_check(schema: &Value, json_obj: &Value, expect_valid: bool) {
     For example, if we have a schema for any integer, then we can always add more digits
     to a valid integer string.
      */
-    assert_eq!(p.is_accepting(), expect_valid, "Final state mismatch");
+    JsonSchemaMatch::Complete(p.is_accepting())
+}
+
+/// Return whether a JSON value is accepted by a JSON-schema grammar.
+pub fn json_schema_accepts(schema: &Value, json_obj: &Value) -> bool {
+    match json_schema_match(schema, json_obj) {
+        JsonSchemaMatch::Complete(accepting) => accepting,
+        JsonSchemaMatch::RejectedAt { .. } => false,
+    }
+}
+
+/// Check that a JSON value is accepted or rejected by a JSON-schema grammar.
+///
+/// Unlike [`lark_str_test`], this function does not use the `FINAL_REJECT:`
+/// convention. Instead it serialises `json_obj`, feeds the tokens, and compares
+/// the parser's result to `expect_valid`.
+pub fn json_schema_check(schema: &Value, json_obj: &Value, expect_valid: bool) {
+    match json_schema_match(schema, json_obj) {
+        JsonSchemaMatch::Complete(accepting) => {
+            assert_eq!(accepting, expect_valid, "Final state mismatch");
+        }
+        JsonSchemaMatch::RejectedAt { token, index } => {
+            assert!(
+                !expect_valid,
+                "Unexpected token: {token} at token index {index}",
+            );
+        }
+    }
 }
 
 pub fn json_test_many(schema: &Value, passing: &[Value], failing: &[Value]) {


### PR DESCRIPTION
## Summary

- replace assertion-driven result classification with a non-panicking acceptance helper
- remove the process-wide no-op panic hook so unexpected runner panics remain visible
- add integration coverage for quiet expected mismatches and visible unexpected panics

## Validation

- `cargo test -p json_schema_test_suite --test panic_reporting`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check --no-default-features -p llguidance`
- `cargo build --locked`
- debug nextest: 1,637 tests passed
- release nextest: 1,637 tests passed

Fixes #358