### PR TITLE
fix: handle non-lossless forced tokenization

### DIFF
--- a/parser/src/tokenparser.rs
+++ b/parser/src/tokenparser.rs
@@ -707,9 +707,18 @@ impl TokenParser {
         if do_force {
             let t0 = Instant::now();
             let (mut tokens, mut num_fixed) = self.token_env.tokenize_bytes_marker(&forced_bytes);
+            let trie = self.token_env.tok_trie();
+            // Healing offsets are invalid when tokenization normalizes the forced bytes.
+            if num_fixed == 0 && trie.decode_raw(&tokens) != forced_bytes {
+                infoln!(
+                    self,
+                    "non-lossless forced-byte tokenization; falling back to byte prefix"
+                );
+                token_prefix = forced_bytes[num_existing_bytes..].to_vec();
+                return (Vec::new(), token_prefix);
+            }
             if !tokens.starts_with(&existing_tokens) {
                 // whoops, re-tokenize without the prefix
-                let trie = self.token_env.tok_trie();
                 infoln!(
                     self,
                     "re-tokenizing without prefix: {}; because we got {}",

--- a/parser/tests/test_raw_parser.rs
+++ b/parser/tests/test_raw_parser.rs
@@ -2,7 +2,7 @@ use lazy_static::lazy_static;
 use llguidance::{
     api::TopLevelGrammar,
     earley::SlicedBiasComputer,
-    toktrie::{ApproximateTokEnv, InferenceCapabilities, TokEnv, TokenizerEnv},
+    toktrie::{ApproximateTokEnv, InferenceCapabilities, TokEnv, TokRxInfo, TokTrie, TokenizerEnv},
     Matcher, ParserFactory, TokenParser,
 };
 use serde_json::{json, Value};
@@ -61,6 +61,42 @@ fn consume(parser: &mut TokenParser, tok: u32) {
     assert!(n == 0);
 }
 
+struct NormalizingTokEnv {
+    trie: TokTrie,
+}
+
+impl NormalizingTokEnv {
+    fn new() -> Self {
+        let mut words = (0..=255).map(|byte| vec![byte]).collect::<Vec<_>>();
+        words.extend([
+            br#"{""#.to_vec(),
+            b"title".to_vec(),
+            br#"":"#.to_vec(),
+            br#"":""#.to_vec(),
+            b"\xff<eos>".to_vec(),
+        ]);
+        let info = TokRxInfo::new(words.len() as u32, words.len() as u32 - 1);
+        Self {
+            trie: TokTrie::from(&info, &words),
+        }
+    }
+}
+
+impl TokenizerEnv for NormalizingTokEnv {
+    fn tok_trie(&self) -> &TokTrie {
+        &self.trie
+    }
+
+    fn tokenize_bytes(&self, bytes: &[u8]) -> Vec<u32> {
+        let normalized = bytes
+            .iter()
+            .copied()
+            .filter(|byte| *byte != b' ')
+            .collect::<Vec<_>>();
+        self.trie.greedy_tokenize(&normalized)
+    }
+}
+
 #[test]
 fn test_ff_tokens() {
     let lark = r#"
@@ -89,6 +125,39 @@ fn test_ff_tokens() {
     assert_eq!(t, vec![311, 1111]);
     let n = parser.validate_tokens_raw(&t).unwrap();
     assert_eq!(n, 2);
+}
+
+#[test]
+fn test_non_lossless_forced_tokenization_falls_back_to_byte_prefix() {
+    const OPEN_OBJECT_QUOTE: u32 = 256;
+    const TITLE: u32 = 257;
+    const QUOTE_COLON: u32 = 258;
+
+    let tok_env: TokEnv = Arc::new(NormalizingTokEnv::new());
+    let factory = ParserFactory::new_simple(&tok_env).unwrap();
+    let grammar = TopLevelGrammar::from_json_schema(json!({
+        "type": "object",
+        "properties": {"title": {"type": "string", "minLength": 1}},
+        "required": ["title"],
+        "x-guidance": {
+            "item_separator": ", ",
+            "key_separator": ": ",
+            "whitespace_flexible": false,
+            "whitespace_pattern": "",
+        },
+    }));
+    let mut matcher = Matcher::new(factory.create_parser(grammar));
+
+    for token in [OPEN_OBJECT_QUOTE, TITLE] {
+        let mask = matcher.compute_mask().unwrap();
+        assert!(mask.is_allowed(token));
+        matcher.consume_token(token).unwrap();
+    }
+
+    let mask = matcher.compute_mask().unwrap();
+    assert!(!mask.is_allowed(b':' as u32));
+    assert!(mask.is_allowed(QUOTE_COLON));
+    matcher.consume_token(QUOTE_COLON).unwrap();
 }
 
 fn get_tok_env() -> &'static TokEnv {


### PR DESCRIPTION
## Summary

- detect when fast-forward tokenization normalizes forced bytes and cannot round-trip them
- fall back to byte-prefix masking so healing offsets stay aligned with parser state
- add a tokenizer-agnostic regression test covering normalization across a JSON key separator

## Root cause

`ff_tokens()` computed healing offsets from decoded token lengths even when tokenization had normalized the original forced byte sequence. With the Step-3.7 tokenizer, the separator space in `": "` was removed during tokenization, so mask generation allowed a bare colon that token consumption rejected.

## Validation

- `cargo test -p llguidance`
- `cargo clippy -p llguidance --all-targets --all-features -- -D warnings`
- `cargo check --no-default-features -p llguidance`
- `cargo fmt --all -- --check`
- reproduced with `stepfun-ai/Step-3.7-Flash`: bare colon is excluded and every allowed token at the failing state consumes successfully

Fixes #366
