### PR TITLE
earley: resolve boundary tokens to the narrowest token-range spec

### DIFF
--- a/parser/src/earley/lexer.rs
+++ b/parser/src/earley/lexer.rs
@@ -160,7 +160,15 @@ impl Lexer {
 
     pub fn force_lexeme_end(&self, prev: StateID) -> LexerResult {
         let info = self.state_info(prev);
-        match info.possible.first() {
+        // When several lexemes are possible at this state (a committed token on the
+        // boundary of multiple active token-range specs), pick the narrowest
+        // (smallest token_range_span) — the most specific one. `possible.first()`
+        // would pick the broad free-text set and freeze the parse.
+        let narrowest = info
+            .possible
+            .iter()
+            .min_by_key(|idx| self.spec.lexemes[idx.as_usize()].token_range_span());
+        match narrowest {
             Some(idx) => LexerResult::Lexeme(PreLexeme::just_idx(MatchingLexemesIdx::Single(idx))),
             None => LexerResult::Error,
         }

--- a/parser/src/earley/lexerspec.rs
+++ b/parser/src/earley/lexerspec.rs
@@ -123,6 +123,16 @@ impl LexemeSpec {
     pub fn contains_token(&self, token: TokenId) -> bool {
         self.token_ranges.iter().any(|range| range.contains(&token))
     }
+
+    /// Total number of token ids covered by this spec's `token_ranges`.
+    /// Used to prefer the most specific (narrowest) lexeme when a committed
+    /// token falls on the boundary of several active token-range specs.
+    pub fn token_range_span(&self) -> u64 {
+        self.token_ranges
+            .iter()
+            .map(|r| (*r.end()) as u64 - (*r.start()) as u64 + 1)
+            .sum()
+    }
 }
 
 impl Debug for LexemeSpec {
@@ -614,5 +624,50 @@ impl Lexeme {
 
     pub fn all_bytes(&self) -> &[u8] {
         &self.bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec_with_ranges(ranges: Vec<RangeInclusive<TokenId>>) -> LexemeSpec {
+        LexemeSpec {
+            idx: LexemeIdx(0),
+            single_set: MatchingLexemes::None,
+            name: String::new(),
+            rx: RegexAst::NoMatch,
+            class: LexemeClass(0),
+            compiled_rx: ExprRef::INVALID,
+            ends_at_eos: false,
+            lazy: false,
+            contextual: false,
+            max_tokens: usize::MAX,
+            is_extra: false,
+            is_suffix: false,
+            is_skip: false,
+            skip_repetition: SkipRepetition::Unbounded,
+            json_options: None,
+            token_ranges: ranges,
+        }
+    }
+
+    #[test]
+    fn test_token_range_span_narrow_vs_broad() {
+        // A single-token range (the EOR marker) has span 1.
+        let narrow = spec_with_ranges(vec![5431..=5431]);
+        assert_eq!(narrow.token_range_span(), 1);
+
+        // A broad range (the reasoning free-text set) has a larger span.
+        let broad = spec_with_ranges(vec![5426..=5432]);
+        assert_eq!(broad.token_range_span(), 7);
+
+        // The narrow spec must sort before the broad one — this is the ordering
+        // the boundary fix relies on (most the most specific lexeme).
+        assert!(narrow.token_range_span() < broad.token_range_span());
+
+        // Multi-range span is the sum of the individual ranges.
+        let multi = spec_with_ranges(vec![10..=12, 20..=21]);
+        assert_eq!(multi.token_range_span(), 3 + 2);
     }
 }

--- a/parser/src/earley/parser.rs
+++ b/parser/src/earley/parser.rs
@@ -1137,13 +1137,25 @@ impl ParserState {
 
     fn flush_and_check_numeric(&mut self, tok_id: TokenId) -> Option<LexemeIdx> {
         if self.flush_lexer() {
+            // A committed token can fall on the boundary of several active
+            // token-range specs (e.g. the reasoning EOR is inside both the broad
+            // free-text set and the narrow <[EOR]> set). Resolve to the narrowest
+            // (smallest token_range_span) — the most specific lexeme. First-match
+            // would pick the broad set, stall the earley 'start' item, and freeze
+            // the DFA on the reasoning state.
+            let mut best: Option<&LexemeSpec> = None;
             for spec in self.token_range_lexemes() {
-                if spec.contains_token(tok_id) {
-                    return Some(spec.idx);
+                if !spec.contains_token(tok_id) {
+                    continue;
+                }
+                if best.map_or(true, |b| spec.token_range_span() < b.token_range_span()) {
+                    best = Some(spec);
                 }
             }
+            best.map(|s| s.idx)
+        } else {
+            None
         }
-        None
     }
 
     // apply_tokens() "pushes" the bytes in 'tokens' into the lexer and parser.  It is a top-level
@@ -1454,15 +1466,22 @@ impl ParserState {
         // we get here "FF [ 1 2 3 4", no final ']'
         let bytes = &bytes[2..bytes.len()];
         if let Ok(tok_id) = std::str::from_utf8(bytes).unwrap().parse::<u32>() {
-            let idx = specs.iter().position(|spec| {
-                spec.token_ranges
-                    .iter()
-                    .any(|range| range.contains(&tok_id))
-            });
-            debug!("  >> tok_id={} idx={:?}", tok_id, idx);
-            if let Some(idx) = idx {
+            // Prefer the narrowest matching spec (smallest token_range_span) over the
+            // first: a token on the boundary of several active token-range specs must
+            // resolve to the most specific one, or the parse stalls in the broad set.
+            let mut best: Option<&LexemeSpec> = None;
+            for spec in specs.iter().copied() {
+                if !spec.contains_token(tok_id) {
+                    continue;
+                }
+                if best.map_or(true, |b| spec.token_range_span() < b.token_range_span()) {
+                    best = Some(spec);
+                }
+            }
+            debug!("  >> tok_id={} best={:?}", tok_id, best.map(|s| s.idx.as_usize()));
+            if let Some(spec) = best {
                 let pre = PreLexeme {
-                    idx: MatchingLexemesIdx::Single(specs[idx].idx),
+                    idx: MatchingLexemesIdx::Single(spec.idx),
                     byte: Some(b']'),
                     byte_next_row: false,
                 };

--- a/parser/tests/test_ll.rs
+++ b/parser/tests/test_ll.rs
@@ -979,6 +979,41 @@ fn test_ll_numeric_token_for_text() {
 }
 
 #[test]
+fn test_ll_numeric_token_boundary_narrowest() {
+    // 5426 long, 5431 foo, 5432 _calling (Phi-3.5-mini-instruct ids).
+    //
+    // The EOR token 5431 sits on the boundary of two active token-range specs:
+    //   - the broad reasoning set  <[5426-5432]>  (span 7)
+    //   - the narrow EOR marker    <[5431]>       (span 1)
+    //
+    // Before the fix, first-match resolution classified 5431 as the broad set,
+    // so the earley `start` item never advanced past the EOR and the parser
+    // parked in the left-recursive `+` loop — the tool choice stayed masked out.
+    // The narrowest-span resolution must pick <[5431]> so the parse exits the
+    // reasoning block and admits the tool.
+    //
+    // The tool is a CHOICE (5433 | 5434) so it is generated, not fast-forwarded,
+    // which is what exercises the boundary mask.
+    check_lark_grammar(
+        r#"start: reasoning tool
+           reasoning: (<[5426-5432]>)+ (<[5431]>)
+           tool: <[5433]> | <[5434]>
+        "#,
+        &["", "<[5426]>‧<[5431]>‧<[5433]>"],
+    );
+
+    // Multi-iteration reasoning block: several broad-set tokens, then the
+    // boundary EOR, then the tool choice. The EOR must resolve to the narrow spec.
+    check_lark_grammar(
+        r#"start: reasoning tool
+           reasoning: (<[5426-5432]>)+ (<[5431]>)
+           tool: <[5433]> | <[5434]>
+        "#,
+        &["", "<[5426]>‧<[5427]>‧<[5431]>‧<[5434]>"],
+    );
+}
+
+#[test]
 fn test_ll_numeric_and_text() {
     check_lark_grammar(
         r#"start: <[5432]> <[5426]> | "qux"


### PR DESCRIPTION
When working with explicit token range grammars (negated to express "anything legal to write in this region") such as:
```lark
start: reasoning_block ( text | tool_call )+ eos
reasoning_block: text (<[248069]>)
text: (<[^248044-248046,248058-248059,248068-248069]>)+
tool_call: <[248058]> tool_content <[248059]>
param_0_0: "\n<parameter=url>\n" value_string
param_0_1: "\n<parameter=proxy>\n" value_string
tool_0: "\n<function=fetch_url_via_curl>" param_0_0 (param_0_1)? "</function>\n"
...
tool_content: tool_0 | tool_1 | tool_2 | tool_3 | tool_4
value_string[suffix="\n</parameter>\n"]: /[\x20-\x7E\x0A\x0D]+?/
eos: ( <[248046]> | <[248044]> )
```
the DFA was not properly representing the ability to start tool calls from within the text region or end reasoning on occasion... the DFA state updates twice (numeric then byte by byte) with the second pass merging special tokens in the <[token_id]> notation to the ~free text mask around them - effectively collapsing-away an edge of the graph. Caught the discrepancy in the DFA from the PDA state in #380 during debugging which led to this TOCTOU-looking fun-fest in the sub-basements of LLG :smile: 

> A committed token that falls on the boundary of several active <[range]> token-range lexemes was classified by first-match to the broadest of them. The reasoning EOR (e.g. 248069) is a member of both the broad reasoning free-text set (<[0-248043,248047-248057,248060-248067,248069-248076]>) and the narrow EOR marker (<[248069]>). First-match picked the broad set, so the earley "start" item never advanced past the EOR: the parser parked in the left-recursive "plus" ("+") loop, the DFA re-seed froze on the reasoning state, and the grammar mask collapsed to the 248071-id reasoning set, masking out the tool tokens 248058 / 248059 / 248046. Tool calls therefore garbled under full-envelope (XINFER_LLG_FULL=1) decoding.
> 
> The pushdown automaton (an independent, exact compilation of the same grammar) advanced correctly through the EOR to the choice-point control state, whose settled-state input set included the tool-start terminal. The DFA/earley path did not. That divergence proves the transition was real and the defect lay in the DFA-side lexeme resolution, not in the grammar or the PDA.
> 
> Fix: at the three sites that resolve a committed token to a token-range lexeme, prefer the narrowest matching spec (smallest token_range_span) over first-match:
> 
>   - earley/parser.rs  flush_and_check_numeric()  (numeric fast-path)
>   - earley/lexer.rs   force_lexeme_end()          (forced lexeme end)
>   - earley/parser.rs  special_pre_lexeme()        (special-token marker)
> 
> Add LexemeSpec::token_range_span() as the shared measure of a spec's specificity (the total number of token ids it covers). A single-token E has span 1; a broad free-text set has span ~vocab. Narrowest-first is the correct disambiguation at a boundary because the dedicated marker is always more specific than the set that happens to contain the same id.
> 
> Tests:
>   - test_ll::test_ll_numeric_token_boundary_narrowest: end-to-end boundary grammar (reasoning "+(<[5426-5432]>)" then "<[5431]>" EOR then a tool choice). Fails without the fix (EOR mis-classified as the broad set, tool choice masked out), passes with it.
>   - lexerspec::tests::test_token_range_span_narrow_vs_broad: unit check of the span measure (narrow < broad, multi-range sums).